### PR TITLE
fix: prevent host aichallenge mount from overriding eval image contents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ x-autoware-eval-base: &autoware-eval-base
     - ./output:${OUTPUT_ROOT:-/output}
     # /aichallenge is baked into the eval image; intentionally not mounted here
     # - ./aichallenge:/aichallenge
-    - ./remote:/remote
-    - ./vehicle:/vehicle
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
     # Audio (PipeWire/Pulse) socket access on the host
     - /run/user:/run/user:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ x-autoware-base: &autoware-base
 
 x-autoware-eval-base: &autoware-eval-base
   <<: *autoware-base
-  image: "aichallenge-2025-eval"
   volumes:
     - ./output:${OUTPUT_ROOT:-/output}
     # /aichallenge is baked into the eval image; intentionally not mounted here
@@ -93,6 +92,7 @@ services:
 
   autoware-simulator-evaluation:
     <<: *autoware-eval-base
+    image: "aichallenge-2025-eval"
     command: ["bash", "-lc", "exec /aichallenge/run_evaluation.bash"]
 
 ### Autoware Service For Parallel Execution ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,21 @@ x-autoware-base: &autoware-base
     - /dev/input
   working_dir: ${LOG_DIR:-/aichallenge}
 
+x-autoware-eval-base: &autoware-eval-base
+  <<: *autoware-base
+  image: "aichallenge-2025-eval"
+  volumes:
+    - ./output:${OUTPUT_ROOT:-/output}
+    # /aichallenge is baked into the eval image; intentionally not mounted here
+    # - ./aichallenge:/aichallenge
+    - ./remote:/remote
+    - ./vehicle:/vehicle
+    - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    # Audio (PipeWire/Pulse) socket access on the host
+    - /run/user:/run/user:rw
+    - /dev/dri:/dev/dri
+    - ${XAUTHORITY}:${XAUTHORITY}:rw
+
 x-racing_kart_interface-base: &racing_kart_interface-base
   image: "ghcr.io/tier4/racing_kart_interface:latest-experiment"
   privileged: true
@@ -77,27 +92,27 @@ services:
     command: ["bash", "-lc", "cd ${CMD_WORKDIR:-/aichallenge} && exec bash -lc \"${CMD:-}\""]
 
   autoware-simulator-evaluation:
-    <<: *autoware-base 
+    <<: *autoware-eval-base
     command: ["bash", "-lc", "exec /aichallenge/run_evaluation.bash"]
 
 ### Autoware Service For Parallel Execution ###
   autoware-d1:
-    <<: *autoware-base 
+    <<: *autoware-eval-base
     image: "autoware-d1"
     command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=1 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=1 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
 
   autoware-d2:
-    <<: *autoware-base 
+    <<: *autoware-eval-base
     image: "autoware-d2"
     command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=2 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=2 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
 
   autoware-d3:
-    <<: *autoware-base
+    <<: *autoware-eval-base
     image: "autoware-d3"
     command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=3 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=3 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
 
   autoware-d4:
-    <<: *autoware-base
+    <<: *autoware-eval-base
     image: "autoware-d4"
     command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=4 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=4 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
 


### PR DESCRIPTION
## 概要

- `make eval` および `run_parallel_submissions.bash` では提出用tarのAutowareが使用されるのが自然
- しかし、提出用tarでビルドされたAutowareは使用されておらず、ホスト側の `./aichallenge` がマウントされて使われていた
  - 特に`run_parallel_submissions.bash`では複数のPlayerで同じソースを使うことになってしまうため、致命的な問題
- 本PRではこれを修正します


## 変更内容

- `autoware-base` を使うと、`./aichallenge:/aichallenge` のマウントが行われてしまう。そのため、このマウントを行わない `autoware-eval-base` を作成
- `make eval` と `autoware-d1` で使われるサービスを `autoware-base` から `autoware-simulator-evaluation` に変更。その後、適切なイメージを使うように上書き

## テスト

### 準備

```
curl -fsSL "https://raw.githubusercontent.com/AutomotiveAIChallenge/aichallenge-racingkart/main/setup.bash" | bash
cd aichallenge-racingkart
make down

git checkout fix/use_eval_image_and_keep_aichallenge
```

### make evalのテスト

```
./create_submit_file.bash
./docker_build.sh eval

# ホストPCの~/aichallenge-racingkart/aichallenge/workspace/src/aichallenge_submitを適当に変更

make eval

# ホストPCに加えた変更は反映されておらず、./create_submit_file.bashした時点のコードが動いていることを確認
# (本PR前は、ホストPCの変更が反映されてしまう)

make down
```

### run_parallel_submissions.bashのテスト

```
# MPC (default) の提出物を作りリネームする
./create_submit_file.bash
mv submit/aichallenge_submit.tar.gz submit/aichallenge_submit_mpc.tar.gz

# pure_pursuit の提出物を作りリネームする
# reference.launch.xmlを編集して、control_methodのdefaultをpure_pursuitにする
./create_submit_file.bash
mv submit/aichallenge_submit.tar.gz submit/aichallenge_submit_pure.tar.gz

./run_parallel_submissions.bash --submit ./submit/aichallenge_submit_pure.tar.gz ./submit/aichallenge_submit_mpc.tar.gz

# D1がpure_pursuit、D2がMPCになっていることを確認
# (本PR前はD1とD2どちらも同じアルゴリズムになってしまう)

make down
```

<img width="2210" height="1538" alt="image" src="https://github.com/user-attachments/assets/1661ae99-9626-4334-a43a-6bb462cb6355" />
