### PR TITLE
feat: add parallel submission in one docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,13 +57,13 @@ ENV RCUTILS_COLORIZED_OUTPUT=0
 ARG SUBMIT_TAR=submit/aichallenge_submit.tar.gz
 
 COPY ${SUBMIT_TAR} /tmp/s.tgz
-RUN git clone --depth 1 https://github.com/AutomotiveAIChallenge/aichallenge-racingkart /t \
+RUN git clone -b feat/add-parallel-sub-in-one-docker --depth 1 https://github.com/AutomotiveAIChallenge/aichallenge-racingkart /t \
  && mv /t/aichallenge /aichallenge \
  && rm -rf /aichallenge/simulator /aichallenge/workspace/src/aichallenge_submit /t \
  && chmod 757 /aichallenge \
  && tar zxf /tmp/s.tgz -C /aichallenge/workspace/src \
  && rm /tmp/s.tgz
-COPY aichallenge/simulator/ /aichallenge/simulator/
+# COPY aichallenge/simulator/ /aichallenge/simulator/
 
 
 RUN bash -c ' \
@@ -71,6 +71,36 @@ RUN bash -c ' \
     cd /aichallenge/workspace; \
     rosdep update; \
     rosdep install -y -r -i --from-paths src --ignore-src --rosdistro $ROS_DISTRO; \
-    python3 -c "from colcon_core.command import main; import sys; sys.exit(main())" build --symlink-install --allow-overriding gyro_odometer --cmake-args -DCMAKE_BUILD_TYPE=Release'
+    colcon build --symlink-install --allow-overriding gyro_odometer --cmake-args -DCMAKE_BUILD_TYPE=Release; \
+    chmod -R a+rwX /aichallenge/workspace/install'
 
 CMD ["bash", "/aichallenge/run_evaluation.bash"]
+
+FROM eval AS parallel
+
+# eval の SUBMIT_TAR（D1）は継承
+# 追加の D2, D3 のみ定義
+ARG SUBMIT_TAR_D2=submit/aichallenge_submit2.tar.gz
+ARG SUBMIT_TAR_D3=submit/aichallenge_submit3.tar.gz
+
+# D2, D3 用の submission を展開
+COPY ${SUBMIT_TAR_D2} /tmp/s2.tgz
+COPY ${SUBMIT_TAR_D3} /tmp/s3.tgz
+RUN mkdir -p /aichallenge/d2/workspace/src /aichallenge/d3/workspace/src \
+ && tar zxf /tmp/s2.tgz -C /aichallenge/d2/workspace/src \
+ && tar zxf /tmp/s3.tgz -C /aichallenge/d3/workspace/src \
+ && rm /tmp/s2.tgz /tmp/s3.tgz
+
+# Build D2-D3 in parallel (independent workspaces)
+RUN bash -c ' \
+    source /aichallenge/workspace/install/setup.bash; \
+    for d in 2 3; do \
+        ( cd /aichallenge/d${d}/workspace; \
+          rosdep install -y -r -i --from-paths src --ignore-src --rosdistro $ROS_DISTRO || true; \
+          colcon build --symlink-install --allow-overriding gyro_odometer --cmake-args -DCMAKE_BUILD_TYPE=Release || true; \
+          chmod -R a+rwX /aichallenge/d${d}/workspace/install || true; \
+        ) & \
+    done; \
+    wait'
+
+CMD ["bash", "/aichallenge/run_parallel.bash"]

--- a/aichallenge/run_parallel.bash
+++ b/aichallenge/run_parallel.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ts="$(date +%Y%m%d-%H%M%S)"
+out_dir="/output/${ts}"
+mkdir -p "${out_dir}"
+cd "${out_dir}" || exit
+mkdir -p "${out_dir}/ros/log"
+
+log_file="${out_dir}/autoware.log"
+export ROS_HOME="${out_dir}/ros"
+export ROS_LOG_DIR="${ROS_HOME}/log"
+# Keep launch output in-file while still streaming to container stdout.
+exec > >(tee -a "${log_file}") 2>&1
+
+exec ros2 launch aichallenge_system_launch parallel.launch.xml \
+    "log_dir:=${out_dir}"

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
@@ -14,7 +14,7 @@
     <let name="domain_id" value="$(var domain_id)"/>
     <let name="rviz_config" value="$(find-pkg-share aichallenge_system_launch)/config/autoware_vehicle.rviz"/>
     <let name="rviz_config" value="$(find-pkg-share aichallenge_system_launch)/config/autoware.rviz" if="$(var simulation)"/>
-    <arg name="rviz_config" default="$(var rviz_config_file)" description="rviz config"/>
+    <arg name="rviz_config" default="$(var rviz_config)" description="rviz config"/>
 
     <log message="The arguments for aichallenge_system_launch."/>
     <log message=" - simulation: $(var simulation)"/>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/parallel.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/parallel.launch.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+    <arg name="vehicles" default="3"/>
+    <arg name="log_dir" default="/output"/>
+    <arg name="laps" default="6"/>
+    <arg name="timeout" default="600"/>
+    <arg name="capture" default="true"/>
+    <arg name="rosbag" default="true"/>
+    <arg name="simulation" default="true"/>
+    <arg name="use_sim_time" default="true"/>
+    <arg name="run_rviz" default="true"/>
+
+    <log message="Launching parallel evaluation ($(var vehicles) vehicles)."/>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="0"/>
+
+        <executable
+            name="aichallenge_awsim_eval"
+            cwd="$(var log_dir)"
+            output="both"
+            cmd="/aichallenge/simulator/AWSIM/AWSIM.x86_64 --vehicles $(var vehicles) --npcs 0 --laps $(var laps) --timeout $(var timeout) --boosts 2 --start-mode sync --start-count-seconds 5 --collisions on --ranking on --sound off"/>
+
+        <include file="$(find-pkg-share aichallenge_system_launch)/launch/mode/awsim_state_manager.launch.xml"/>
+    </group>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="1"/>
+        <set_env name="ROS_HOME" value="$(var log_dir)/d1/ros"/>
+        <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d1/ros/log"/>
+        <include file="$(find-pkg-share aichallenge_system_launch)/launch/aichallenge_system.launch.xml">
+            <arg name="simulation" value="$(var simulation)"/>
+            <arg name="use_sim_time" value="$(var use_sim_time)"/>
+            <arg name="run_rviz" value="$(var run_rviz)"/>
+            <arg name="capture" value="$(var capture)"/>
+            <arg name="rosbag" value="$(var rosbag)"/>
+            <arg name="domain_id" value="1"/>
+        </include>
+    </group>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="2"/>
+        <set_env name="ROS_HOME" value="$(var log_dir)/d2/ros"/>
+        <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d2/ros/log"/>
+        <executable name="autoware_d2" output="screen" cmd="bash -c 'source /aichallenge/d2/workspace/install/setup.bash &amp;&amp; exec ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=false capture:=true rosbag:=true domain_id:=2'"/>
+    </group>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="3"/>
+        <set_env name="ROS_HOME" value="$(var log_dir)/d3/ros"/>
+        <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d3/ros/log"/>
+        <executable name="autoware_d3" output="screen" cmd="bash -c 'source /aichallenge/d3/workspace/install/setup.bash &amp;&amp; exec ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=false capture:=true rosbag:=true domain_id:=3'"/>
+    </group>
+
+</launch>

--- a/design_docs/one_docker_run.md
+++ b/design_docs/one_docker_run.md
@@ -1,0 +1,172 @@
+
+# 単一Docker内の複数Autoware並列実行
+
+## 概要
+
+1つのDockerコンテナ内で3つの異なる参加者コードを **同時実行** できる仕組み。
+各参加者コードは異なるROS Domain IDで独立した通信空間を持つ。
+
+## アーキテクチャ
+
+```
+1つのDocker (aichallenge-2025-parallel)
+├── /aichallenge/workspace/              ← D1（eval から継承）
+├── /aichallenge/d2/workspace/           ← D2 提出物
+└── /aichallenge/d3/workspace/           ← D3 提出物
+
+各ワークスペースは独立した colcon build（--symlink-install）
+
+↓ parallel.launch.xml が全体を起動
+
+├── Domain ID 0: AWSIM Simulator + awsim_state_manager
+├── Domain ID 1: Autoware D1 （<include> で直接起動）
+├── Domain ID 2: Autoware D2 （bash -c で D2 workspace を source して起動）
+└── Domain ID 3: Autoware D3 （bash -c で D3 workspace を source して起動）
+
+↓ domain_bridge で Domain 0 ↔ Domain 1-3 を接続
+
+出力ディレクトリ:
+/output/<timestamp>/
+├── d1/ros/log/    ← D1 の ROS ログ
+├── d2/ros/log/    ← D2 の ROS ログ
+└── d3/ros/log/    ← D3 の ROS ログ
+```
+
+## 実装詳細
+
+### 1. Dockerfile（parallel ターゲット）
+
+eval ステージを継承し、D2-D3 ワークスペースを追加ビルド：
+
+```dockerfile
+FROM eval AS parallel
+
+ARG SUBMIT_TAR_D2=submit/aichallenge_submit2.tar.gz
+ARG SUBMIT_TAR_D3=submit/aichallenge_submit3.tar.gz
+
+COPY ${SUBMIT_TAR_D2} /tmp/s2.tgz
+COPY ${SUBMIT_TAR_D3} /tmp/s3.tgz
+RUN mkdir -p /aichallenge/d2/workspace/src /aichallenge/d3/workspace/src \
+ && tar zxf /tmp/s2.tgz -C /aichallenge/d2/workspace/src \
+ && tar zxf /tmp/s3.tgz -C /aichallenge/d3/workspace/src \
+ && rm /tmp/s2.tgz /tmp/s3.tgz
+
+# D2-D3 を並列ビルド
+RUN bash -c ' \
+    source /aichallenge/workspace/install/setup.bash; \
+    for d in 2 3; do \
+        ( cd /aichallenge/d${d}/workspace; \
+          colcon build --symlink-install ...; \
+          chmod -R a+rwX /aichallenge/d${d}/workspace/install || true; \
+        ) & \
+    done; \
+    wait'
+
+CMD ["bash", "/aichallenge/run_parallel.bash"]
+```
+
+**ポイント:**
+
+- D2-D3 ビルド時に D1 workspace を source（`aichallenge_system_launch` 等の依存解決）
+- `chmod -R a+rwX` で install dir の書き込み権限を付与（rocker 非root ユーザー対応）
+- D2-D3 は並列ビルド（独立ワークスペース）
+
+### 2. parallel.launch.xml
+
+1つの launch ファイルで Simulator + 3台の Autoware を起動。
+各ドメインは `<set_env>` で `ROS_DOMAIN_ID`、`ROS_HOME`、`ROS_LOG_DIR` を分離：
+
+```xml
+<!-- D1: entrypoint で source 済みなので直接 include -->
+<group>
+    <set_env name="ROS_DOMAIN_ID" value="1"/>
+    <set_env name="ROS_HOME" value="$(var log_dir)/d1/ros"/>
+    <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d1/ros/log"/>
+    <include file=".../aichallenge_system.launch.xml">
+        <arg name="domain_id" value="1"/>
+    </include>
+</group>
+
+<!-- D2-D3: bash -c で各 workspace を source してから launch -->
+<group if="$(eval $(var vehicles)>=2)">
+    <set_env name="ROS_DOMAIN_ID" value="2"/>
+    <set_env name="ROS_HOME" value="$(var log_dir)/d2/ros"/>
+    <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d2/ros/log"/>
+    <executable name="autoware_d2" output="screen" cmd="bash -c &quot;
+        source /aichallenge/d2/workspace/install/setup.bash &amp;&amp;
+        exec ros2 launch aichallenge_system_launch aichallenge_system.launch.xml
+            simulation:=$(var simulation) domain_id:=2 ...
+    &quot;"/>
+</group>
+```
+
+**設計判断:**
+
+- D1 は `<include>` で起動（entrypoint が D1 workspace を source 済み）
+- D2-D3 は `<executable cmd="bash -c ...">` で起動（`<set_env AMENT_PREFIX_PATH>` は `$(find-pkg-share)` に効かないため）
+- D2-D3 の `capture`/`rosbag` 等のパラメータは親の `$(var ...)` から伝搬
+- 各ドメインの `ROS_HOME`/`ROS_LOG_DIR` を `<set_env>` で分離し、ログの混在を防止
+
+### 3. run_parallel.bash
+
+`parallel.launch.xml` を起動するエントリポイント：
+
+```bash
+#!/usr/bin/env bash
+ts="$(date +%Y%m%d-%H%M%S)"
+out_dir="/output/${ts}"
+# ... ログ設定 ...
+exec ros2 launch aichallenge_system_launch parallel.launch.xml \
+    "log_dir:=${out_dir}" "simulation:=true" ...
+```
+
+## ビルドと実行
+
+```bash
+# ビルド（3つの submission を指定）
+./docker_build.sh parallel --submit a.tar.gz b.tar.gz c.tar.gz
+
+# 実行
+./docker_run.sh parallel
+```
+
+## 実装状況
+
+| ファイル | 説明 | 状態 |
+| --- | --- | --- |
+| `Dockerfile` | parallel ターゲット（D2-D3 ワークスペース） | done |
+| `docker_build.sh` | ビルドスクリプト（`--submit` で3つ指定） | done |
+| `docker_run.sh` | 実行スクリプト（parallel ターゲット対応） | done |
+| `parallel.launch.xml` | Simulator + D1-D3 並列起動 | done |
+| `aichallenge_system.launch.xml` | `rviz_config` 引数の外部指定対応 | done |
+| `run_parallel.bash` | parallel.launch.xml のエントリポイント | done |
+
+## 動作フロー
+
+```text
+./docker_build.sh parallel --submit a.tar.gz b.tar.gz c.tar.gz
+    ↓
+1. docker build --target parallel
+   ├─ eval ステージで D1 ビルド
+   └─ parallel ステージで D2-D3 並列ビルド
+    ↓
+./docker_run.sh parallel
+    ↓
+2. rocker で aichallenge-2025-parallel コンテナ起動
+   └─ /aichallenge/run_parallel.bash が実行
+    ↓
+3. parallel.launch.xml が起動
+   ├─ AWSIM (Domain 0, --vehicles 3, --start-mode sync)
+   ├─ awsim_state_manager (Domain 0)
+   ├─ Autoware D1 (Domain 1, <include>)
+   ├─ Autoware D2 (Domain 2, bash -c + source d2 workspace)
+   └─ Autoware D3 (Domain 3, bash -c + source d3 workspace)
+    ↓
+4. 結果出力: /output/<timestamp>/d{1-3}/
+```
+
+## 技術的な注意点
+
+- eval stage は `--target eval` でも `--target parallel` でも同一の処理。parallel は `FROM eval AS parallel` で継承するだけなので、eval の動作保証は壊れない
+- D2-D3 ビルド時は `/aichallenge/workspace/install/setup.bash`（D1）を source する（`aichallenge_system_launch` の依存解決に必要）
+- 各ドメインの `ROS_HOME`/`ROS_LOG_DIR` は `<set_env>` でドメインごとに分離（`/output/<ts>/d{N}/ros/`）

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -8,15 +8,34 @@ shift || true
 SUBMIT_TAR="${SUBMIT_TAR-}"
 
 if [ -z "${target}" ]; then
-    echo "Usage: ./docker_build.sh <dev|eval> [--submit <path/to/aichallenge_submit.tar.gz>]" >&2
+    cat >&2 <<'EOF'
+Usage: ./docker_build.sh <dev|eval|parallel> [options]
+
+Commands:
+  dev       開発モード（AWSIM + Autoware D1）
+  eval      評価モード（Autoware D1）
+  parallel  複数並列実行（D1-D3、3台）
+
+Options:
+  --submit <path> [...]  提出物 tar.gz ファイル（eval: 1つ, parallel: 3つ）
+
+Examples:
+  ./docker_build.sh dev
+  ./docker_build.sh eval --submit path/to/submit.tar.gz
+  ./docker_build.sh parallel --submit a.tar.gz b.tar.gz c.tar.gz
+EOF
     exit 2
 fi
 
+submits=()
 while [ $# -gt 0 ]; do
     case "$1" in
-    --submit | --submit-tar)
-        SUBMIT_TAR="${2-}"
-        shift 2
+    --submit)
+        shift
+        while [ $# -gt 0 ] && [[ $1 != --* ]]; do
+            submits+=("$1")
+            shift
+        done
         ;;
     --)
         shift
@@ -24,21 +43,29 @@ while [ $# -gt 0 ]; do
         ;;
     *)
         echo "invalid argument: '$1'" >&2
-        echo "Usage: ./docker_build.sh <dev|eval> [--submit <path/to/aichallenge_submit.tar.gz>]" >&2
         exit 2
         ;;
     esac
 done
 
+if [ "${target}" = "eval" ]; then
+    SUBMIT_TAR="${submits[0]-${SUBMIT_TAR}}"
+elif [ "${target}" = "parallel" ]; then
+    [ ${#submits[@]} -eq 3 ] || {
+        echo "[ERROR] parallel requires exactly 3 submission files" >&2
+        exit 1
+    }
+fi
+
 case "${target}" in
-"eval")
+"eval" | "parallel")
     opts="--no-cache"
     ;;
 "dev")
     opts=""
     ;;
 *)
-    echo "invalid argument (use 'dev' or 'eval')"
+    echo "invalid argument (use 'dev', 'eval', or 'parallel')"
     exit 1
     ;;
 esac
@@ -56,8 +83,21 @@ if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     fi
     BUILD_ARGS+=(--build-arg "SUBMIT_TAR=${SUBMIT_TAR}")
     echo "[INFO] Using submit tar: ${SUBMIT_TAR}"
-elif [ "$target" != "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
-    echo "[WARN] --submit is only used for target=eval (ignored): ${SUBMIT_TAR}" >&2
+elif [ "$target" = "parallel" ]; then
+    # parallel: D1 は SUBMIT_TAR（eval ステージ）、D2-D3 は SUBMIT_TAR_D{N}
+    for i in 1 2 3; do
+        tar_file="${submits[$((i - 1))]}"
+        if [ ! -f "${tar_file}" ]; then
+            echo "[ERROR] submit file not found: ${tar_file}" >&2
+            exit 1
+        fi
+        if [ "$i" -eq 1 ]; then
+            BUILD_ARGS+=(--build-arg "SUBMIT_TAR=${tar_file}")
+        else
+            BUILD_ARGS+=(--build-arg "SUBMIT_TAR_D${i}=${tar_file}")
+        fi
+        echo "[INFO] D${i}: ${tar_file}"
+    done
 fi
 
 # shellcheck disable=SC2086

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -5,7 +5,7 @@ device="${2}"
 device_drivers="/dev/dri"
 
 case "${target}" in
-"eval")
+"eval" | "parallel")
     volume="output:/output /run/user:/run/user:rw"
     ;;
 "dev")
@@ -17,7 +17,7 @@ case "${target}" in
     exit 1
     ;;
 *)
-    echo "invalid argument (use 'dev' or 'eval')"
+    echo "invalid argument (use 'dev', 'eval', or 'parallel')"
     exit 1
     ;;
 esac
@@ -41,5 +41,9 @@ LOG_FILE="output/docker/${ts}-docker_run-$$.log"
 mkdir -p output/docker output/latest
 ln -sfn "${PWD}/${LOG_FILE}" output/latest/docker_run.log
 
+# dev: interactive bash, eval/parallel: run Dockerfile CMD
+run_args=("aichallenge-2025-${target}")
+[ "${target}" = "dev" ] && run_args+=("bash")
+
 # shellcheck disable=SC2086
-rocker ${opts} --x11 --devices ${device_drivers} --user --pulse --net host --privileged --name "aichallenge-2025-$(date "+%Y-%m-%d-%H-%M-%S")" --volume ${volume} -- "aichallenge-2025-${target}" bash 2>&1 | tee "$LOG_FILE"
+rocker ${opts} --x11 --devices ${device_drivers} --user --pulse --net host --privileged --name "aichallenge-2025-$(date "+%Y-%m-%d-%H-%M-%S")" --volume ${volume} -- "${run_args[@]}" 2>&1 | tee "$LOG_FILE"

--- a/vehicle/cyclonedds.xml
+++ b/vehicle/cyclonedds.xml
@@ -9,7 +9,7 @@
       <MaxMessageSize>65500B</MaxMessageSize>
     </General>
     <Internal>
-      <SocketReceiveBufferSize min="10MB"/>
+      <SocketReceiveBufferSize min="0B"/>
       <Watermarks>
         <WhcHigh>500kB</WhcHigh>
       </Watermarks>


### PR DESCRIPTION

```.md
# 単一Docker内の複数Autoware並列実行

## 概要

1つのDockerコンテナ内で4つの異なる参加者コードを **同時実行** できる仕組み。
各参加者コードは異なるROS Domain IDで独立した通信空間を持つ。

## アーキテクチャ

```
1つのDocker (aichallenge-2025-parallel)
├── /aichallenge/workspace/              ← D1（eval から継承）
├── /aichallenge/d2/workspace/           ← D2 提出物
├── /aichallenge/d3/workspace/           ← D3 提出物
└── /aichallenge/d4/workspace/           ← D4 提出物

各ワークスペースは独立した colcon build（--symlink-install）

↓ parallel.launch.xml が全体を起動

├── Domain ID 0: AWSIM Simulator + awsim_state_manager
├── Domain ID 1: Autoware D1 （<include> で直接起動）
├── Domain ID 2: Autoware D2 （bash -c で D2 workspace を source して起動）
├── Domain ID 3: Autoware D3 （bash -c で D3 workspace を source して起動）
└── Domain ID 4: Autoware D4 （bash -c で D4 workspace を source して起動）

↓ domain_bridge で Domain 0 ↔ Domain 1-4 を接続
```

## 実装詳細

### 1. Dockerfile（parallel ターゲット）

eval ステージを継承し、D2-D4 ワークスペースを追加ビルド：

```dockerfile
FROM eval AS parallel

ARG SUBMIT_TAR_D2=submit/aichallenge_submit2.tar.gz
ARG SUBMIT_TAR_D3=submit/aichallenge_submit3.tar.gz
ARG SUBMIT_TAR_D4=submit/aichallenge_submit4.tar.gz

RUN mkdir -p /aichallenge/d2/workspace/src /aichallenge/d3/workspace/src /aichallenge/d4/workspace/src

# D2-D4 submission 展開
COPY ${SUBMIT_TAR_D2} /tmp/s2.tgz
RUN tar zxf /tmp/s2.tgz -C /aichallenge/d2/workspace/src && rm /tmp/s2.tgz
# ... D3, D4 も同様

# D1 workspace を source してから D2-D4 をビルド + 権限付与
RUN bash -c ' \
    source /aichallenge/workspace/install/setup.bash; \
    for d in 2 3 4; do \
        cd /aichallenge/d${d}/workspace; \
        colcon build --symlink-install ...; \
        chmod -R 777 /aichallenge/d${d}/workspace/install || true; \
    done'

CMD ["bash", "/aichallenge/run_parallel.bash"]
```

**ポイント:**
- D2-D4 ビルド時に D1 workspace を source（`aichallenge_system_launch` 等の依存解決）
- `chmod -R 777` で install dir の書き込み権限を付与（rocker 非root ユーザー対応）

### 2. parallel.launch.xml

1つの launch ファイルで Simulator + 4台の Autoware を起動：

```xml
<!-- Simulator (Domain 0) -->
<group>
    <set_env name="ROS_DOMAIN_ID" value="0"/>
    <executable cmd="AWSIM.x86_64 --start-mode sync --vehicles $(var vehicles) ..."/>
    <include file=".../awsim_state_manager.launch.xml"/>
</group>

<!-- D1: entrypoint で source 済みなので直接 include -->
<group>
    <set_env name="ROS_DOMAIN_ID" value="1"/>
    <include file=".../aichallenge_system.launch.xml">
        <arg name="domain_id" value="1"/>
    </include>
</group>

<!-- D2-D4: bash -c で各 workspace を source してから launch -->
<group if="$(eval $(var vehicles)>=2)">
    <executable name="autoware_d2" output="screen"
        cmd="bash -c &quot;source /aichallenge/d2/workspace/install/setup.bash
             &amp;&amp; exec env ROS_DOMAIN_ID=2 ros2 launch aichallenge_system_launch
             aichallenge_system.launch.xml domain_id:=2
             rviz_config:=.../autoware_minimal.rviz ...&quot;"/>
</group>
<!-- D3, D4 も同様 -->
```

**設計判断:**
- D1 は `<include>` で起動（entrypoint が D1 workspace を source 済み）
- D2-D4 は `<executable cmd="bash -c ...">` で起動（`<set_env AMENT_PREFIX_PATH>` は `$(find-pkg-share)` に効かないため）
- D2-D4 は `autoware_minimal.rviz`（ControlModePanel のみ）を使用し、リソース節約

### 3. run_parallel.bash

`parallel.launch.xml` を起動するエントリポイント：

```bash
#!/usr/bin/env bash
domain_id="${ROS_DOMAIN_ID:-${DOMAIN_ID:-1}}"
ts="$(date +%Y%m%d-%H%M%S)"
out_dir="/output/${ts}/d${domain_id}"
# ... ログ設定 ...
exec ros2 launch aichallenge_system_launch parallel.launch.xml \
    "log_dir:=${out_dir}" "simulation:=true" ...
```

### 4. autoware_minimal.rviz

D2-D4 用の軽量 rviz config。ControlModePanel のみ含む：

```yaml
Panels:
  - Class: aichallenge_control_rviz_plugin/ControlModePanel
    Name: ControlModePanel
# Display なし、最小ウィンドウ
```

## ビルドと実行

```bash
# ビルド（4つの submission を指定）
./docker_build.sh parallel --submit a.tar.gz b.tar.gz c.tar.gz d.tar.gz

# 実行
./docker_run.sh parallel
```

## 実装状況

| ファイル | 説明 | 状態 |
|---|---|---|
| `Dockerfile` | parallel ターゲット（D2-D4 ワークスペース） | ✅ |
| `docker_build.sh` | ビルドスクリプト（`--submit` で4つ指定） | ✅ |
| `docker_run.sh` | 実行スクリプト（parallel ターゲット対応） | ✅ |
| `parallel.launch.xml` | Simulator + D1-D4 並列起動 | ✅ |
| `aichallenge_system.launch.xml` | `rviz_config` 引数の外部指定対応 | ✅ |
| `run_parallel.bash` | parallel.launch.xml のエントリポイント | ✅ |
| `autoware_minimal.rviz` | D2-D4 用軽量 rviz config | ✅ |

## 動作フロー

```
./docker_build.sh parallel --submit a.tar.gz b.tar.gz c.tar.gz d.tar.gz
    ↓
1. docker build --target parallel
   ├─ eval ステージで D1 ビルド
   └─ parallel ステージで D2-D4 ビルド
    ↓
./docker_run.sh parallel
    ↓
2. rocker で aichallenge-2025-parallel コンテナ起動
   └─ /aichallenge/run_parallel.bash が実行
    ↓
3. parallel.launch.xml が起動
   ├─ AWSIM (Domain 0, --vehicles 4, --start-mode sync)
   ├─ awsim_state_manager (Domain 0)
   ├─ Autoware D1 (Domain 1, <include>)
   ├─ Autoware D2 (Domain 2, bash -c + source d2 workspace)
   ├─ Autoware D3 (Domain 3, bash -c + source d3 workspace)
   └─ Autoware D4 (Domain 4, bash -c + source d4 workspace)
    ↓
4. 結果出力: /output/<timestamp>/d{1-4}/
```

## 技術的な注意点

- D2-D4 ビルド時は `/aichallenge/workspace/install/setup.bash`（D1）を source する（`aichallenge_system_launch` の依存解決に必要）