### PR TITLE
feat: improve parallel execution in single Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,37 @@ RUN bash -c ' \
     python3 -c "from colcon_core.command import main; import sys; sys.exit(main())" build --symlink-install --allow-overriding gyro_odometer --cmake-args -DCMAKE_BUILD_TYPE=Release'
 
 CMD ["bash", "/aichallenge/run_evaluation.bash"]
+
+FROM eval AS parallel
+
+# D2, D3, D4 submission tarballs (D1 is already built by eval stage)
+ARG SUBMIT_TAR_D2=submit/aichallenge_submit2.tar.gz
+ARG SUBMIT_TAR_D3=submit/aichallenge_submit3.tar.gz
+ARG SUBMIT_TAR_D4=submit/aichallenge_submit4.tar.gz
+
+# Create D2-D4 workspaces (D1 = /aichallenge/workspace already exists from eval)
+RUN mkdir -p /aichallenge/d2/workspace/src /aichallenge/d3/workspace/src /aichallenge/d4/workspace/src
+
+COPY ${SUBMIT_TAR_D2} /tmp/s2.tgz
+RUN tar zxf /tmp/s2.tgz -C /aichallenge/d2/workspace/src && rm /tmp/s2.tgz
+
+COPY ${SUBMIT_TAR_D3} /tmp/s3.tgz
+RUN tar zxf /tmp/s3.tgz -C /aichallenge/d3/workspace/src && rm /tmp/s3.tgz
+
+COPY ${SUBMIT_TAR_D4} /tmp/s4.tgz
+RUN tar zxf /tmp/s4.tgz -C /aichallenge/d4/workspace/src && rm /tmp/s4.tgz
+
+# Build D2-D4 workspaces (D1 already built by eval stage)
+RUN bash -c ' \
+    source /autoware/install/setup.bash; \
+    for d in 2 3 4; do \
+        echo "=== Building workspace D${d} ==="; \
+        cd /aichallenge/d${d}/workspace; \
+        rosdep install -y -r -i --from-paths src --ignore-src --rosdistro $ROS_DISTRO || true; \
+        python3 -c "from colcon_core.command import main; import sys; sys.exit(main())" build --symlink-install --allow-overriding gyro_odometer --cmake-args -DCMAKE_BUILD_TYPE=Release || true; \
+    done'
+
+COPY aichallenge/run_parallel.bash /aichallenge/run_parallel.bash
+RUN chmod +x /aichallenge/run_parallel.bash
+
+CMD ["bash", "/aichallenge/run_parallel.bash"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 .PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control autoware-driver-zenoh \
-	simulator simulator-reset dev driver zenoh download rviz2 down ps
+	simulator simulator-reset dev driver zenoh download rviz2 down ps parallel
 
 # Used by docker-compose.yml for build/eval artifact ownership.
 HOST_UID ?= $(shell id -u)
@@ -10,6 +10,7 @@ HOST_GID ?= $(shell id -g)
 export HOST_UID HOST_GID
 
 DOMAIN_ID ?= 1
+VEHICLES ?= 4
 TIMESTAMP := $(shell date +%Y%m%d-%H%M%S)
 LOG_DIR ?= /output/$(TIMESTAMP)/d$(DOMAIN_ID)
 
@@ -62,6 +63,11 @@ dev: simulator autoware-simulator
 eval:
 	@echo "Start evaluation simulation (AWSIM + Autoware, DOMAIN_ID=$(DOMAIN_ID))"
 	docker compose up -d autoware-simulator-evaluation
+	@echo "To stop: make down  (docker compose down --remove-orphans)"
+
+parallel:
+	@echo "Start parallel evaluation ($(VEHICLES) vehicles)"
+	VEHICLES=$(VEHICLES) docker compose up -d autoware-parallel
 	@echo "To stop: make down  (docker compose down --remove-orphans)"
 
 # remote operation (docker compose up -d rviz2)

--- a/aichallenge/run_parallel.bash
+++ b/aichallenge/run_parallel.bash
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Run multiple Autoware instances in parallel, each with a distinct ROS Domain ID.
+# The simulator runs on Domain 0; participants run on Domain 1..N.
+
+set -euo pipefail
+
+# Number of parallel vehicles (default: 4, max: 4)
+vehicles="${VEHICLES:-4}"
+if (( vehicles < 1 || vehicles > 4 )); then
+    echo "[ERROR] VEHICLES must be between 1 and 4 (got: ${vehicles})" >&2
+    exit 1
+fi
+
+# Determine simulator mode based on vehicle count
+sim_mode="${SIM_MODE:-${vehicles}p}"
+
+ts="$(date +%Y%m%d-%H%M%S)"
+
+# Create output directories for each domain
+for i in $(seq 1 "$vehicles"); do
+    mkdir -p "/output/${ts}/d${i}/ros/log"
+done
+
+# --- Trap for graceful shutdown ---
+declare -a ALL_PIDS=()
+cleanup() {
+    echo "[INFO] Shutting down all processes..."
+    for pid in "${ALL_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# --- Start simulator (Domain 0) ---
+echo "[INFO] Starting AWSIM in '${sim_mode}' mode (vehicles=${vehicles})"
+export ROS_DOMAIN_ID=0
+/aichallenge/run_simulator.bash "${sim_mode}" &
+SIM_PID=$!
+ALL_PIDS+=("$SIM_PID")
+
+# Wait for simulator to initialise
+sleep 10
+
+# --- Start Autoware for each domain ---
+declare -a AW_PIDS=()
+for i in $(seq 1 "$vehicles"); do
+    out_dir="/output/${ts}/d${i}"
+    log_file="${out_dir}/autoware.log"
+
+    # D1 uses the default workspace; D2-D4 use /aichallenge/d{N}/workspace
+    if [ "$i" -eq 1 ]; then
+        ws="/aichallenge/workspace"
+    else
+        ws="/aichallenge/d${i}/workspace"
+    fi
+
+    (
+        export ROS_DOMAIN_ID="$i"
+        export ROS_HOME="${out_dir}/ros"
+        export ROS_LOG_DIR="${ROS_HOME}/log"
+        # Source the workspace-specific overlay
+        # shellcheck disable=SC1091
+        source /autoware/install/setup.bash
+        if [ -f "${ws}/install/local_setup.bash" ]; then
+            # shellcheck disable=SC1091
+            source "${ws}/install/local_setup.bash"
+        fi
+
+        cd "${out_dir}"
+        echo "[INFO] Starting Autoware D${i} (ROS_DOMAIN_ID=${i}, workspace=${ws})"
+        exec ros2 launch aichallenge_system_launch evaluation.launch.xml \
+            "domain_id:=${i}" \
+            "sim_mode:=eval" \
+            "log_dir:=${out_dir}" \
+            "capture:=true" \
+            "rosbag:=true" \
+            "simulation:=true" \
+            "use_sim_time:=true" \
+            "run_rviz:=false"
+    ) > "${log_file}" 2>&1 &
+    AW_PIDS+=($!)
+    ALL_PIDS+=($!)
+    echo "[INFO] Autoware D${i} started (PID=$!)"
+done
+
+# --- Wait for completion ---
+echo "[INFO] Waiting for all Autoware instances to finish..."
+aw_exit=0
+for pid in "${AW_PIDS[@]}"; do
+    wait "$pid" || aw_exit=$?
+done
+
+echo "[INFO] All Autoware instances finished (last exit: ${aw_exit}). Waiting for simulator..."
+wait "$SIM_PID" || true
+
+echo "[INFO] Parallel execution complete. Results in /output/${ts}/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,26 +93,20 @@ services:
     image: "aichallenge-2025-eval"
     command: ["bash", "-lc", "exec /aichallenge/run_evaluation.bash"]
 
-### Autoware Service For Parallel Execution ###
-  autoware-d1:
+### Parallel Execution: single container running AWSIM + N Autoware instances ###
+  autoware-parallel:
     <<: *autoware-eval-base
-    image: "autoware-d1"
-    command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=1 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=1 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
-
-  autoware-d2:
-    <<: *autoware-eval-base
-    image: "autoware-d2"
-    command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=2 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=2 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
-
-  autoware-d3:
-    <<: *autoware-eval-base
-    image: "autoware-d3"
-    command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=3 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=3 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
-
-  autoware-d4:
-    <<: *autoware-eval-base
-    image: "autoware-d4"
-    command: ["bash", "-lc", "exec env ROS_DOMAIN_ID=4 ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true domain_id:=4 > \"${LOG_DIR:-/output}/autoware.log\" 2>&1"]
+    image: "aichallenge-2025-parallel"
+    environment:
+      - DISPLAY=${DISPLAY}
+      - USER=${USER}
+      - ROS_DISTRO=humble
+      - XAUTHORITY=${XAUTHORITY}
+      - QT_X11_NO_MITSHM=1
+      - TZ=Asia/Tokyo
+      - VEHICLES=${VEHICLES:-4}
+      - SIM_MODE=${SIM_MODE:-}
+    command: ["bash", "-lc", "exec /aichallenge/run_parallel.bash"]
 
 #### vehicle specific services can be added here ####
   # Zenoh service

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -8,27 +8,53 @@ shift || true
 SUBMIT_TAR="${SUBMIT_TAR-}"
 
 if [ -z "${target}" ]; then
-    echo "Usage: ./docker_build.sh <dev|eval> [--submit <path/to/aichallenge_submit.tar.gz>]" >&2
+    cat >&2 <<'EOF'
+Usage: ./docker_build.sh <dev|eval|parallel> [options]
+
+Commands:
+  dev                       開発モード
+  eval  --submit <tar.gz>   評価モード
+  parallel <t1> [t2] [t3] [t4]  複数並列実行（D1-D4、最大4台）
+
+Examples:
+  ./docker_build.sh dev
+  ./docker_build.sh eval --submit path/to/submit.tar.gz
+  ./docker_build.sh parallel team_a.tar.gz team_b.tar.gz team_c.tar.gz team_d.tar.gz
+EOF
     exit 2
 fi
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-    --submit | --submit-tar)
-        SUBMIT_TAR="${2-}"
-        shift 2
-        ;;
-    --)
-        shift
-        break
-        ;;
-    *)
-        echo "invalid argument: '$1'" >&2
-        echo "Usage: ./docker_build.sh <dev|eval> [--submit <path/to/aichallenge_submit.tar.gz>]" >&2
-        exit 2
-        ;;
-    esac
-done
+# Collect arguments depending on target
+declare -a submits=()
+if [ "${target}" = "parallel" ]; then
+    # Remaining positional args are submission tarballs
+    submits=("$@")
+    if [ ${#submits[@]} -eq 0 ]; then
+        echo "[ERROR] parallel requires at least one submission file" >&2
+        exit 1
+    fi
+    if [ ${#submits[@]} -gt 4 ]; then
+        echo "[ERROR] parallel supports maximum 4 submissions (got ${#submits[@]})" >&2
+        exit 1
+    fi
+else
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        --submit | --submit-tar)
+            SUBMIT_TAR="${2-}"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "invalid argument: '$1'" >&2
+            exit 2
+            ;;
+        esac
+    done
+fi
 
 case "${target}" in
 "eval")
@@ -37,8 +63,11 @@ case "${target}" in
 "dev")
     opts=""
     ;;
+"parallel")
+    opts="--no-cache"
+    ;;
 *)
-    echo "invalid argument (use 'dev' or 'eval')"
+    echo "invalid argument (use 'dev', 'eval', or 'parallel')"
     exit 1
     ;;
 esac
@@ -56,6 +85,29 @@ if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     fi
     BUILD_ARGS+=(--build-arg "SUBMIT_TAR=${SUBMIT_TAR}")
     echo "[INFO] Using submit tar: ${SUBMIT_TAR}"
+elif [ "$target" = "parallel" ]; then
+    # D1 uses the base SUBMIT_TAR arg from the eval stage
+    d1_tar="${submits[0]}"
+    if [ ! -f "${d1_tar}" ]; then
+        echo "[ERROR] D1 submit file not found: ${d1_tar}" >&2
+        exit 1
+    fi
+    BUILD_ARGS+=(--build-arg "SUBMIT_TAR=${d1_tar}")
+    echo "[INFO] D1: ${d1_tar}"
+
+    # D2-D4 use SUBMIT_TAR_D{N}
+    for i in 2 3 4; do
+        idx=$((i - 1))
+        if [ $idx -lt ${#submits[@]} ]; then
+            tar_file="${submits[$idx]}"
+            if [ ! -f "${tar_file}" ]; then
+                echo "[ERROR] D${i} submit file not found: ${tar_file}" >&2
+                exit 1
+            fi
+            BUILD_ARGS+=(--build-arg "SUBMIT_TAR_D${i}=${tar_file}")
+            echo "[INFO] D${i}: ${tar_file}"
+        fi
+    done
 elif [ "$target" != "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     echo "[WARN] --submit is only used for target=eval (ignored): ${SUBMIT_TAR}" >&2
 fi


### PR DESCRIPTION
## Summary

ドラフトPRの並列実行設計を改善・実装したものです。

- **Dockerfile**: `parallel` マルチステージターゲットを追加。D1はevalステージから継承済みのため重複展開を排除し、D2-D4のみ追加ビルド
- **run_parallel.bash**: AWSIM + N台のAutowareを並列起動。各ドメインごとにワークスペース固有の`setup.bash`をsource、シグナルハンドリングによるgraceful shutdown対応
- **docker_build.sh**: `parallel` コマンドで複数submission tarを指定可能に（最大4つ）
- **docker-compose.yml**: 個別の`autoware-d1`〜`autoware-d4`サービスを単一の`autoware-parallel`サービスに統合
- **Makefile**: `make parallel VEHICLES=N` ターゲットを追加

### ドラフトPRからの改善点

| 項目 | ドラフトPR | 本PR |
|---|---|---|
| D1 tarの展開 | evalとparallelで二重展開 | evalの結果を継承（重複なし） |
| ワークスペース分離 | `run_evaluation.bash`をそのまま使用 | 各ドメインでワークスペース固有の`local_setup.bash`をsource |
| シグナルハンドリング | なし | `trap`によるgraceful shutdown |
| Simulator mode | 固定 | 車両数に応じて自動設定（`${vehicles}p`） |
| docker-compose | 個別サービス(d1-d4)が残存 | 単一`autoware-parallel`サービスに統合 |
| `docker_build.sh` | 未定義変数`${build_target}`を参照 | 修正済み |
| rviz | 全ドメインで起動 | 並列時はrviz無効（リソース節約） |

## 使い方

```bash
# ビルド
./docker_build.sh parallel team_a.tar.gz team_b.tar.gz team_c.tar.gz team_d.tar.gz

# 実行
make parallel VEHICLES=4
```

## Test plan

- [ ] `bash -n` によるスクリプト構文チェック（通過済み）
- [ ] `docker compose config` による設定バリデーション（通過済み）
- [ ] 4つのsubmission tarを指定して `docker_build.sh parallel` でビルド確認
- [ ] `make parallel VEHICLES=2` で2台並列実行の動作確認
- [ ] 各ドメインのログが `/output/<timestamp>/d{1..N}/` に分離されることを確認

https://claude.ai/code/session_01Gops4DwvZrJQnDRsF5CKne