### PR TITLE
fix: docker log ownership and prevent rclpy shutdown hang

### DIFF
--- a/aichallenge/run_autoware.bash
+++ b/aichallenge/run_autoware.bash
@@ -2,7 +2,7 @@
 
 mode="${1}"
 id="${2:-0}" # デフォルト値0を設定
-out_dir="${3}"
+out_dir="${3:-/output/$(date +%Y%m%d-%H%M%S)/d${id}}"
 
 case "${mode}" in
 "awsim")
@@ -25,11 +25,10 @@ esac
 
 export ROS_DOMAIN_ID=$id
 
-ts="$(date +%Y%m%d-%H%M%S)"
-out_dir="${out_dir:-/output/${ts}/d${id}}"
 mkdir -p "${out_dir}"
+trap 'bash /aichallenge/utils/fix_ownership.bash "${HOST_UID}" "${HOST_GID}" /output "$(dirname "${out_dir}")"' EXIT
+
 cd "${out_dir}" || exit
-mkdir -p "${out_dir}/ros/log"
 # Persist ROS node logs under the run output directory (so autostart_orchestrator logs are collectible).
 export ROS_HOME="${out_dir}/ros"
 export ROS_LOG_DIR="${ROS_HOME}/log"

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -3,7 +3,10 @@
 domain_id="${ROS_DOMAIN_ID:-${DOMAIN_ID:-1}}"
 ts="$(date +%Y%m%d-%H%M%S)"
 out_dir="/output/${ts}/d${domain_id}"
+
 mkdir -p "${out_dir}"
+trap 'bash /aichallenge/utils/fix_ownership.bash "${HOST_UID}" "${HOST_GID}" /output "$(dirname "${out_dir}")"' EXIT
+
 cd "${out_dir}" || exit
 mkdir -p "${out_dir}/ros/log"
 
@@ -15,7 +18,7 @@ exec > >(tee -a "${log_file}") 2>&1
 
 sim_mode="${SIM_MODE:-eval}"
 
-exec ros2 launch aichallenge_system_launch evaluation.launch.xml \
+ros2 launch aichallenge_system_launch evaluation.launch.xml \
     "domain_id:=${domain_id}" \
     "sim_mode:=${sim_mode}" \
     "log_dir:=${out_dir}" \

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -26,7 +26,4 @@ ros2 launch aichallenge_system_launch evaluation.launch.xml \
     "rosbag:=true" \
     "simulation:=true" \
     "use_sim_time:=true" \
-    "run_rviz:=true" &
-launch_pid=$!
-trap 'kill -TERM "${launch_pid}" 2>/dev/null || true' TERM INT
-wait "${launch_pid}"
+    "run_rviz:=true"

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -26,4 +26,7 @@ ros2 launch aichallenge_system_launch evaluation.launch.xml \
     "rosbag:=true" \
     "simulation:=true" \
     "use_sim_time:=true" \
-    "run_rviz:=true"
+    "run_rviz:=true" &
+launch_pid=$!
+trap 'kill -TERM "${launch_pid}" 2>/dev/null || true' TERM INT
+wait "${launch_pid}"

--- a/aichallenge/utils/fix_ownership.bash
+++ b/aichallenge/utils/fix_ownership.bash
@@ -5,7 +5,7 @@ set -euo pipefail
 HOST_UID="${1-}"
 HOST_GID="${2-}"
 OUTPUT_ROOT="${3:-/output}"
-TS="${4-}"
+TARGET="${4-}"
 
 log() {
     echo "[fix_ownership] $*"
@@ -25,8 +25,8 @@ if [ -z "${HOST_UID}" ] || [ -z "${HOST_GID}" ] || ! is_number "${HOST_UID}" || 
     exit 0
 fi
 
-if [ -z "${TS}" ]; then
-    warn "timestamp not provided. Skipping ownership change."
+if [ -z "${TARGET}" ]; then
+    warn "TARGET not provided. Skipping ownership change."
     exit 0
 fi
 
@@ -35,14 +35,13 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 0
 fi
 
-target="${OUTPUT_ROOT}/${TS}"
 log "Running as root. Changing ownership of artifacts to ${HOST_UID}:${HOST_GID}..."
-log "Target directory: ${target}"
+log "Target directory: ${TARGET}"
 
 # Ensure the output root itself remains writable by the host user.
 chown "${HOST_UID}:${HOST_GID}" "${OUTPUT_ROOT}" || true
-chown -R "${HOST_UID}:${HOST_GID}" "${target}" || true
-chown -h "${HOST_UID}:${HOST_GID}" "${OUTPUT_ROOT}/latest" || true
+chown -R "${HOST_UID}:${HOST_GID}" "${TARGET}" || true
+chown -Rh "${HOST_UID}:${HOST_GID}" "${OUTPUT_ROOT}/latest" || true
 
 log "Ownership change complete."
 exit 0

--- a/aichallenge/utils/fix_ownership.bash
+++ b/aichallenge/utils/fix_ownership.bash
@@ -30,6 +30,15 @@ if [ -z "${TARGET}" ]; then
     exit 0
 fi
 
+case "${TARGET}" in
+    "${OUTPUT_ROOT}"/*)
+        ;;
+    *)
+        warn "TARGET '${TARGET}' is not under OUTPUT_ROOT '${OUTPUT_ROOT}'. Skipping."
+        exit 1
+        ;;
+esac
+
 if [ "$(id -u)" -ne 0 ]; then
     log "Running as non-root user ($(id -u)). Skipping chown."
     exit 0

--- a/aichallenge/utils/fix_ownership.bash
+++ b/aichallenge/utils/fix_ownership.bash
@@ -31,12 +31,11 @@ if [ -z "${TARGET}" ]; then
 fi
 
 case "${TARGET}" in
-    "${OUTPUT_ROOT}"/*)
-        ;;
-    *)
-        warn "TARGET '${TARGET}' is not under OUTPUT_ROOT '${OUTPUT_ROOT}'. Skipping."
-        exit 1
-        ;;
+"${OUTPUT_ROOT}"/*) ;;
+*)
+    warn "TARGET '${TARGET}' is not under OUTPUT_ROOT '${OUTPUT_ROOT}'. Skipping."
+    exit 1
+    ;;
 esac
 
 if [ "$(id -u)" -ne 0 ]; then

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -117,6 +117,8 @@ class AutostartOrchestrator(Node):
         self._cond = threading.Condition()
         self._last_vehicle_state: Optional[str] = None
 
+        rclpy.get_default_context().on_shutdown(self._on_rclpy_shutdown)
+
         self._sub = self.create_subscription(String, vehicle_state_topic, self._on_vehicle_state, 10, callback_group=cbg)
 
         self._cli_initial_pose = self.create_client(
@@ -387,6 +389,10 @@ class AutostartOrchestrator(Node):
         if code and self._exit_code == 0:
             self._exit_code = code
 
+    def _on_rclpy_shutdown(self) -> None:
+        with self._cond:
+            self._cond.notify_all()
+
     def _shutdown(self) -> None:
         if rclpy.ok():
             rclpy.shutdown()
@@ -448,7 +454,7 @@ class AutostartOrchestrator(Node):
             while rclpy.ok():
                 if self._state_matches(self._last_vehicle_state, expected_states):
                     return True, self._last_vehicle_state
-                self._cond.wait()
+                self._cond.wait(timeout=1.0)
         return False, self._last_vehicle_state
 
     def _do_start_initialization(self, call_initial_pose: bool, request_control_mode: bool) -> None:
@@ -987,11 +993,15 @@ def main() -> int:
         node.get_logger().info("KeyboardInterrupt received, shutting down node gracefully.")
     finally:
         exit_code = int(getattr(node, "exit_code", 0))
+        worker = getattr(node, "_worker", None)
         try:
             node.destroy_node()
         finally:
             if rclpy.ok():
                 rclpy.shutdown()
+        if worker is not None and worker.is_alive():
+            worker.join(timeout=5.0)
+        exit_code = max(exit_code, int(getattr(node, "exit_code", 0)))
         return exit_code
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ x-autoware-base: &autoware-base
     - COLCON_TRACE=${COLCON_TRACE:-}
     - ROS_HOME=${ROS_HOME:-}
     - ROS_LOG_DIR=${ROS_LOG_DIR:-}
+    - HOST_UID=${HOST_UID:-}
+    - HOST_GID=${HOST_GID:-}
   volumes:
     - ./output:${OUTPUT_ROOT:-/output}
     - ./aichallenge:/aichallenge


### PR DESCRIPTION
# 概要                                                                                                                                                                                                          
- Dockerコンテナ内でroot権限で作成されたファイルを、ユーザー権限に修正します
- `make eval` で走行終了時に終了処理（`latest` の作成）やコンテナが自動終了しない問題を修正します
  - 本問題は本PR以前から存在しました。上記修正の確認に必要であったため本PRでまとめて修正しました

# 変更内容
- `run_autoware.bash` と `run_evaluation.bash` に `trap ... EXIT `を追加し、スクリプト終了時に必ずログファイルのオーナーシップを修正するようにしました
- これに合わせて、`fix_ownership.bash`を修正しました。他の箇所では未使用なことを確認済み。
  - なお、rockerから起動した場合には権限設定処理はスキップされるため副作用はありません
- `rclpy.shutdown()` 呼び出し時に `autostart_orchestrator` がハングする問題を修正（以下の3点が必要でした。これらがないと、AWSIM終了後にautostart_orchestratorがずっと終了待ちになることがランダムで発生しました）
  - シャットダウンコールバックでの notify
  - wait タイムアウト
  - 終了時のworkerスレッドの処理完了待ち
- `run_evaluation.bash`において`ros2 launch` から `exec` を外しました。理由は、`exec`がついているとPID=1となり終了シグナルが飛ばないためです


# テスト内容

## `make dev`

- [x]  走行中に `make down` 、で生成されるoutput/ログフォルダの所有者がユーザーであること
- [ ]   走行中に `make down` 、で生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
  - 従来同等。本PRでは未対応

## `make eval`

- [x]  既定数走行後、AWSIMとコンテナが自動的に終了すること
- [x]  既定数走行後、生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
- [x]  既定数走行後、生成されるoutput/latestが正しいファイルへのシンボリックリンクになっていること
- [x]  既定数走行後、生成されるoutput/ログフォルダとlatestの所有者がユーザーであること
- [x]  タイムアウト発生後、AWSIMとコンテナが自動的に終了すること
- [x]  タイムアウト発生後、生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
- [x]  タイムアウト発生後、生成されるoutput/latestが正しいファイルへのシンボリックリンクになっていること
- [x]  タイムアウト発生後、生成されるoutput/ログフォルダとlatestの所有者がユーザーであること
- [ ] 走行中に  `make down` 、で生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
  - 従来同等。本PRでは未対応

## rocker (`bash docker_run.sh eval` -> `/aichallenge/run_evaluation.bash` )
- [x]  既定数走行後、AWSIMとコンテナが自動的に終了すること
- [x]  既定数走行後、生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
- [x]  既定数走行後、生成されるoutput/latestが正しいファイルへのシンボリックリンクになっていること
- [x]  既定数走行後、生成されるoutput/ログフォルダとlatestの所有者がユーザーであること
  - デフォルトでユーザー権限になります。本PRで追加した権限設定処理はスキップされます。
- [x]  タイムアウト発生後、AWSIMとコンテナが自動的に終了すること
- [x]  タイムアウト発生後、生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
- [x]  タイムアウト発生後、生成されるoutput/latestが正しいファイルへのシンボリックリンクになっていること
- [x]  タイムアウト発生後、生成されるoutput/ログフォルダとlatestの所有者がユーザーであること
- [x] 走行中にctrl-c後、生成されるoutput/ログフォルダのファイルに欠損・破損がないこと（特にmcap, mp4）
- [x]  走行中にctrl-c後、生成されるoutput/latestが正しいファイルへのシンボリックリンクになっていること