### PR TITLE
chore(mpc): disable save_config

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/config/config.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/config/config.yaml
@@ -1,5 +1,5 @@
 common:
-  save_config: true
+  save_config: false
 
 sim_logger:
   animation_enabled: false


### PR DESCRIPTION
## 背景

- `save_config: true` 設定だと、mpc起動時に以下の場所にconfig.yamlのコピーが保存されます
  - `aichallenge/workspace/install/multi_purpose_mpc_ros/share/multi_purpose_mpc_ros/log`
- `make dev` や `make eval `で実行すると、このフォルダはroot権限で作成されます
- その後、rockerから起動するとユーザー権限で本フォルダに`config.yaml`のコピーを作成しようとします。このとき、権限エラーで失敗して、ノードが死んでしまいます

## 変更内容

`save_config: false` に設定します

## 影響確認

- 実行時に `aichallenge/workspace/install/multi_purpose_mpc_ros/share/multi_purpose_mpc_ros/log` が保存されないようになります
- しかし、本ファイルは参照される可能性は低いです。また、設定値自体はコードのコピー元のconfig.yamlで確認できます


## テスト内容

- [x] `make dev` で起動する
- [x] `aichallenge/workspace/install/multi_purpose_mpc_ros/share/multi_purpose_mpc_ros/log` が生成されていないことを確認する
- [x] rockerから起動する ( `bash docker_run.sh eval` ->  `/aichallenge/run_evaluation.bash` )
- [x] mpcノードが死なないことを確認する
- [x] `aichallenge/workspace/install/multi_purpose_mpc_ros/share/multi_purpose_mpc_ros/log` が生成されていないことを確認する