### PR TITLE
feat(v2x): separate V2X GNSS topics and posers per vehicle domain

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(FROM_DOMAIN RANGE 1 4)
       string(APPEND V2X_OTHER_GNSS_TOPICS
         "  d${_other_domain}/sensing/gnss/nav_sat_fix:\n"
         "    type: sensor_msgs/msg/NavSatFix\n"
-        "    remap: /v2x/gnss/nav_sat_fix\n"
+        "    remap: /v2x/d${_other_domain}/gnss/nav_sat_fix\n"
         "    reversed: True\n"
         "\n"
       )

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz
@@ -16,9 +16,18 @@ Panels:
         - /Control1/PointStamped1/Topic1
         - /Vehicle1
         - /V2X1
-        - /V2X1/GNSS1/Topic1
-        - /V2X1/GNSS1/Covariance1
-        - /V2X1/GNSS1/Covariance1/Position1
+        - /V2X1/D11/Topic1
+        - /V2X1/D11/Covariance1
+        - /V2X1/D11/Covariance1/Position1
+        - /V2X1/D21/Topic1
+        - /V2X1/D21/Covariance1
+        - /V2X1/D21/Covariance1/Position1
+        - /V2X1/D31/Topic1
+        - /V2X1/D31/Covariance1
+        - /V2X1/D31/Covariance1/Position1
+        - /V2X1/D41/Topic1
+        - /V2X1/D41/Covariance1
+        - /V2X1/D41/Covariance1/Position1
       Splitter Ratio: 0.5737704634666443
     Tree Height: 470
   - Class: rviz_common/Views
@@ -324,7 +333,10 @@ Visualization Manager:
               Value: false
               VehicleModel: true
             V2X:
-              GNSS: true
+              D1: true
+              D2: true
+              D3: true
+              D4: true
               Value: false
             Value: true
             Vehicle:
@@ -532,7 +544,7 @@ Visualization Manager:
           Axes Length: 0
           Axes Radius: 0
           Class: rviz_default_plugins/PoseWithCovariance
-          Color: 255; 25; 0
+          Color: 255; 80; 0
           Covariance:
             Orientation:
               Alpha: 0.5
@@ -544,14 +556,14 @@ Visualization Manager:
               Value: false
             Position:
               Alpha: 0.30000001192092896
-              Color: 204; 51; 204
+              Color: 255; 80; 0
               Scale: 0.4000000059604645
               Value: true
             Value: true
           Enabled: true
           Head Length: 0
           Head Radius: 0
-          Name: GNSS
+          Name: D1
           Shaft Length: 0
           Shaft Radius: 0
           Shape: Arrow
@@ -561,7 +573,112 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /v2x/gnss/pose_with_covariance
+            Value: /v2x/d1/gnss/pose_with_covariance
+          Value: true
+        - Alpha: 0
+          Axes Length: 0
+          Axes Radius: 0
+          Class: rviz_default_plugins/PoseWithCovariance
+          Color: 0; 180; 255
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: false
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 0; 180; 255
+              Scale: 0.4000000059604645
+              Value: true
+            Value: true
+          Enabled: true
+          Head Length: 0
+          Head Radius: 0
+          Name: D2
+          Shaft Length: 0
+          Shaft Radius: 0
+          Shape: Arrow
+          Topic:
+            Depth: 10
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /v2x/d2/gnss/pose_with_covariance
+          Value: true
+        - Alpha: 0
+          Axes Length: 0
+          Axes Radius: 0
+          Class: rviz_default_plugins/PoseWithCovariance
+          Color: 0; 220; 80
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: false
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 0; 220; 80
+              Scale: 0.4000000059604645
+              Value: true
+            Value: true
+          Enabled: true
+          Head Length: 0
+          Head Radius: 0
+          Name: D3
+          Shaft Length: 0
+          Shaft Radius: 0
+          Shape: Arrow
+          Topic:
+            Depth: 10
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /v2x/d3/gnss/pose_with_covariance
+          Value: true
+        - Alpha: 0
+          Axes Length: 0
+          Axes Radius: 0
+          Class: rviz_default_plugins/PoseWithCovariance
+          Color: 220; 220; 0
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: false
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 220; 220; 0
+              Scale: 0.4000000059604645
+              Value: true
+            Value: true
+          Enabled: true
+          Head Length: 0
+          Head Radius: 0
+          Name: D4
+          Shaft Length: 0
+          Shaft Radius: 0
+          Shape: Arrow
+          Topic:
+            Depth: 10
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /v2x/d4/gnss/pose_with_covariance
           Value: true
       Enabled: true
       Name: V2X

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
@@ -63,6 +63,8 @@
         <node pkg="domain_bridge" exec="domain_bridge" name="vehicle_domain_bridge" output="screen"
             args="--from $(var domain_id) --to 0 $(find-pkg-share aichallenge_system_launch)/config/domain/d$(var domain_id)_bridge_config.yaml">
         </node>
-        <include file="$(find-pkg-share aichallenge_system_launch)/launch/mode/v2x.launch.xml"/>
+        <include file="$(find-pkg-share aichallenge_system_launch)/launch/mode/v2x.launch.xml">
+            <arg name="domain_id" value="$(var domain_id)"/>
+        </include>
     </group>
 </launch>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/mode/v2x.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/mode/v2x.launch.xml
@@ -1,16 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <!-- V2X -->
+  <arg name="domain_id"/>
+  <!-- V2X: one gnss_poser per other vehicle domain -->
   <group>
     <push-ros-namespace namespace="v2x"/>
-    <group>
-      <push-ros-namespace namespace="gnss"/>
-      <include file="$(find-pkg-share racing_kart_gnss_poser)/launch/gnss_poser.launch.xml">
-        <arg name="input_topic_fix" value="nav_sat_fix"/>
-        <arg name="output_topic_gnss_pose" value="pose"/>
-        <arg name="output_topic_gnss_fixed" value="gnss_fixed"/>
-        <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
-      </include>
+    <group unless="$(eval $(var domain_id)==1)">
+      <push-ros-namespace namespace="d1"/>
+      <group>
+        <push-ros-namespace namespace="gnss"/>
+        <include file="$(find-pkg-share racing_kart_gnss_poser)/launch/gnss_poser.launch.xml">
+          <arg name="input_topic_fix" value="nav_sat_fix"/>
+          <arg name="output_topic_gnss_pose" value="pose"/>
+          <arg name="output_topic_gnss_fixed" value="gnss_fixed"/>
+          <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
+          <arg name="gnss_base_frame" value="d1_gnss_base_link"/>
+        </include>
+      </group>
+    </group>
+    <group unless="$(eval $(var domain_id)==2)">
+      <push-ros-namespace namespace="d2"/>
+      <group>
+        <push-ros-namespace namespace="gnss"/>
+        <include file="$(find-pkg-share racing_kart_gnss_poser)/launch/gnss_poser.launch.xml">
+          <arg name="input_topic_fix" value="nav_sat_fix"/>
+          <arg name="output_topic_gnss_pose" value="pose"/>
+          <arg name="output_topic_gnss_fixed" value="gnss_fixed"/>
+          <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
+          <arg name="gnss_base_frame" value="d2_gnss_base_link"/>
+        </include>
+      </group>
+    </group>
+    <group unless="$(eval $(var domain_id)==3)">
+      <push-ros-namespace namespace="d3"/>
+      <group>
+        <push-ros-namespace namespace="gnss"/>
+        <include file="$(find-pkg-share racing_kart_gnss_poser)/launch/gnss_poser.launch.xml">
+          <arg name="input_topic_fix" value="nav_sat_fix"/>
+          <arg name="output_topic_gnss_pose" value="pose"/>
+          <arg name="output_topic_gnss_fixed" value="gnss_fixed"/>
+          <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
+          <arg name="gnss_base_frame" value="d3_gnss_base_link"/>
+        </include>
+      </group>
+    </group>
+    <group unless="$(eval $(var domain_id)==4)">
+      <push-ros-namespace namespace="d4"/>
+      <group>
+        <push-ros-namespace namespace="gnss"/>
+        <include file="$(find-pkg-share racing_kart_gnss_poser)/launch/gnss_poser.launch.xml">
+          <arg name="input_topic_fix" value="nav_sat_fix"/>
+          <arg name="output_topic_gnss_pose" value="pose"/>
+          <arg name="output_topic_gnss_fixed" value="gnss_fixed"/>
+          <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
+          <arg name="gnss_base_frame" value="d4_gnss_base_link"/>
+        </include>
+      </group>
     </group>
   </group>
 </launch>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/mode/v2x.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/mode/v2x.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="domain_id"/>
+  <arg name="domain_id" default="1"/>
   <!-- V2X: one gnss_poser per other vehicle domain -->
   <group>
     <push-ros-namespace namespace="v2x"/>


### PR DESCRIPTION
## 背景

V2X構成において、全ての他車GNSSデータが単一トピック `/v2x/gnss/nav_sat_fix` に混在していました。これにより以下の問題が生じていました。
- 可視化の問題：複数車両のデータが混在した状態でgnss_poserが処理するため、他車の位置（紫の円）がRViz上でランダムに点滅します
- 可視化の問題：TFフレーム gnss_base_link が複数の処理から競合してpublishされ、他車の位置（tfの矢印）がRViz上でランダムに点滅します
- 制御の問題：全ての車両位置情報が単一トピック `/v2x/gnss/pose_with_covariance` に混在していました。このトピック内でどのメッセージがどの車両のものか区別できません
  - デフォルト構成ではV2X情報は制御に使用されていません。しかし、現状では参加者がV2X情報を使おうとしても情報が混在しているため難しいです

### Before

[Screencast from 04-14-2026 06:45:29 PM.webm](https://github.com/user-attachments/assets/955a42c0-7d18-4292-969f-7182a7f4395c)

### After

[Screencast from 04-14-2026 06:47:54 PM.webm](https://github.com/user-attachments/assets/c6505ad0-3535-4a24-91ba-211435443e9a)

## 変更内容

- CMakeLists.txt
  - 他車GNSSトピックのremapを車両別に分離しました
    - 変更前: `d{X}/sensing/gnss/nav_sat_fix` → `/v2x/gnss/nav_sat_fix`（全車混在）
    - 変更後: `d{X}/sensing/gnss/nav_sat_fix` → `/v2x/d{X}/gnss/nav_sat_fix`（車両別）
- v2x.launch.xml
  - gnss_poserを他車ドメイン（d1〜d4）それぞれに1つずつ起動するよう変更し、出力トピックを車両別に分離しました
      - 変更前: `/v2x/gnss/pose_with_covariance` （全車混在）
      - 変更後: `/v2x/d{X}/gnss/pose_with_covariance` （車両別）
  - domain_id を受け取り、自車ドメインのgnss_poserはスキップします
  - TFフレーム名を車両別（d{X}_gnss_base_link）に設定し、TF競合を解消しました
- aichallenge_system.launch.xml
  - domain_id を v2x.launch.xml に渡すように修正しました
- autoware.rviz
  - V2X表示グループを単一の「GNSS」から車両別（D1〜D4）に分割しました
  - 各車両を異なる色で表示します（D1:オレンジ、D2:水色、D3:緑、D4:黄）

## テスト

具体的なコマンドはコメント内に記載します

- `make dev` でデグレが無いことを確認。特に、自車の位置が正しく表示されることを確認
- `make eval` でデグレが無いことを確認。特に、自車の位置が正しく表示されることを確認
- `run_parallel_submissions` 4台起動でデグレがないことを確認。以下の修正が反映されていることを確認
  - RViz上でD1〜D4の各車両のpose_with_covarianceとtfが個別に表示されることを確認
  - ros2 topic list | grep v2x で /v2x/d{X}/gnss/nav_sat_fix および /v2x/d{X}/gnss/pose_with_covariance が車両別に存在することを確認
  - 自車ドメインに対応するgnss_poserが起動しないことを確認（ros2 node list）
- `run_parallel_submissions` 2台起動でデグレがないことを確認。以下の修正が反映されていることを確認
  - D2,D3車両の情報がRViz上に表示されないこと
  - D2,D3車両のトピックに何もpublishされていないこと
  - 自車ドメインに対応するgnss_poserが起動しないことを確認（ros2 node list）

## V2X情報を制御に使う方法（案）

- 自分のdomain_idに依らず、以下の4トピックを全てcreate_subscriptionします
  - `/v2x/d1/gnss/pose_with_covariance` 〜 `/v2x/d4/gnss/pose_with_covariance`
- 実際にトピックがpublishされるのは、実在する・自車両以外の車両のみです。受信コールバックが呼ばれるトピックは必然的に他車の情報となります
- 例えば、全3台で走行しており、自車のdomain_id = 2の場合、以下の2トピックが実際に使われます
  - `/v2x/d1/gnss/pose_with_covariance`
  - `/v2x/d3/gnss/pose_with_covariance`