### PR TITLE
fix(Makefile): restore dev SIM_MODE and fix ROS_DOMAIN_ID handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 .PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control  autoware-request-start autoware-driver-zenoh \
-	simulator simulator-reset dev dev2 dev3 dev4 driver zenoh download rviz2 down down2 down3 down4 ps
+	simulator simulator-reset dev dev2 dev3 dev4 driver zenoh download rviz2 down down2 down3 down4 ps autoware-bash
 
 # Used by docker-compose.yml for build/eval artifact ownership.
 HOST_UID ?= $(shell id -u)
@@ -105,6 +105,13 @@ ps:
 			echo "$$out"; \
 		fi; \
 	done
+
+autoware-bash:
+	@if [ -z "$(VEHICLE_NUM)" ]; then \
+		docker compose exec autoware bash; \
+	else \
+		docker compose -p $(VEHICLE_NUM) exec autoware bash; \
+	fi
 
 # Download submission data by asking for credentials interactively
 # Usage:

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ HOST_UID ?= $(shell id -u)
 HOST_GID ?= $(shell id -g)
 export HOST_UID HOST_GID
 
-ROS_DOMAIN_ID ?= 1
+ROS_DOMAIN_ID := 1
 TIMESTAMP := $(shell date +%Y%m%d-%H%M%S)
-LOG_DIR ?= /output/$(TIMESTAMP)/d$(ROS_DOMAIN_ID)
+LOG_DIR := /output/$(TIMESTAMP)/d$(ROS_DOMAIN_ID)
 
 # autowareのbuildのみ
 autoware-build:
@@ -40,7 +40,7 @@ autoware-request-start:
 # run simulator (docker compose up -d simulator)
 simulator:
 	@echo "Start AWSIM (SIM_MODE=$(SIM_MODE))"
-	LOG_DIR=$(LOG_DIR) SIM_MODE=$(SIM_MODE) docker compose up -d simulator
+	LOG_DIR=$(LOG_DIR) SIM_MODE=$(SIM_MODE) ROS_DOMAIN_ID=0 docker compose up -d simulator
 
 simulator-reset:
 	@echo "Reset simulation"
@@ -55,6 +55,7 @@ driver:
 zenoh:
 	docker compose up -d zenoh
 
+dev: SIM_MODE := dev
 dev: simulator autoware-simulator
 	@echo "Start dev simulation (AWSIM + Autoware, ROS_DOMAIN_ID=$(ROS_DOMAIN_ID))"
 	@echo "To stop: make down  (docker compose down --remove-orphans)"


### PR DESCRIPTION
## 内容

- https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/195 で入った、下記不具合の修正です
  - `make dev` で起動時に走行開始できない
    - 下記の問題とは別。仮にROS_DOMAIN_IDが未設定でも問題発生します
  - AWSIMとAutowareが同じROS_DOMAIN_IDで動いてしまう
    - 下記の問題とは別。仮にROS_DOMAIN_IDが未設定でも問題発生します
  - ホスト環境でROS_DOMAIN_IDを設定していると、その設定が引き継がれてしまう

## 変更内容

- `make dev` のときにSIM_MODEが未設定になっていたため、 `SIM_MODE := dev` を追加しました
  - 走行開始しないのはこれが原因です
- ROS_DOMAIN_ID設定用の変数が、従来は `DOMAIN_ID` だったが `ROS_DOMAIN_ID` に変わりました。また、初期値の設定に `?=` を使っているため、ホスト環境の設定を引き継いでいました。ホストの設定を引き継ぐ必要はないため、必ず1を設定するようにしました
- AWSIM起動する `docker compose up -d simulator` で、`ROS_DOMAIN_ID=0` を設定しました。理由は、 `docker-compose.yml` で `- ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-1}` が追加されて未設定だと1になってしまうためです
- `make autoware-bash` コマンドを追加して、`docker compose exec autoware bash` を簡略化しました

## テスト

- `make dev` で起動して、走行開始できること。その後、 `make down` で終了できること。
- `make dev4` で起動して、走行開始できること。その後、 `make down` で終了できること。
- `/AWSIM` ノードが、ROS_DOMAIN_ID=0で起動していること
- `make dev` で起動したとき、`make autoware-bash` でAutowareコンテナに入れること
- `make dev4` で起動したとき、`make autoware-bash VEHICLE_NUM=4` でp4のAutowareコンテナに入れること

