### PR TITLE
fix: autostart orchestrator shutdown and qt lifecycle

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -494,14 +494,18 @@ class AutostartOrchestrator(Node):
 
         self._set_workflow_state(self._STATE_REQUEST_CONTROL_MODE, "initialization done")
 
-    def _wait_for_service(self, client, timeout_sec: float = _SERVICE_WAIT_TIMEOUT_SEC) -> bool:
+    def _wait_for_service(self, client, timeout_sec: Optional[float] = None) -> bool:
+        if timeout_sec is None:
+            timeout_sec = self._SERVICE_WAIT_TIMEOUT_SEC
         try:
             return bool(client.wait_for_service(timeout_sec=timeout_sec))
         except Exception as exc:  # noqa: BLE001
             self.get_logger().warn(f"wait_for_service failed: {exc}")
             return False
 
-    def _call_trigger(self, client, timeout_sec: float = _SERVICE_CALL_TIMEOUT_SEC) -> tuple[bool, str]:
+    def _call_trigger(self, client, timeout_sec: Optional[float] = None) -> tuple[bool, str]:
+        if timeout_sec is None:
+            timeout_sec = self._SERVICE_CALL_TIMEOUT_SEC
         event = threading.Event()
         result: tuple[bool, str] = (False, "no_response")
 
@@ -519,6 +523,7 @@ class AutostartOrchestrator(Node):
 
         future.add_done_callback(_done)
         if not event.wait(timeout=timeout_sec):
+            future.cancel()
             return False, f"timeout after {timeout_sec}s"
         return result
 

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -57,8 +57,8 @@ class AutostartOrchestrator(Node):
     _ANSI_BOLD = "\033[1m"
     _ANSI_RESET = "\033[0m"
 
-    _SERVICE_WAIT_TIMEOUT_SEC = 5.0
-    _SERVICE_CALL_TIMEOUT_SEC = 10.0
+    _SERVICE_WAIT_TIMEOUT_SEC_DEFAULT = 5.0
+    _SERVICE_CALL_TIMEOUT_SEC_DEFAULT = 10.0
 
     def _require_parameter(self, name: str) -> object:
         value = self.get_parameter(name).value

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -523,6 +523,8 @@ class AutostartOrchestrator(Node):
 
         future.add_done_callback(_done)
         if not event.wait(timeout=timeout_sec):
+            if event.is_set():
+                return result
             future.cancel()
             return False, f"timeout after {timeout_sec}s"
         return result

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -57,6 +57,9 @@ class AutostartOrchestrator(Node):
     _ANSI_BOLD = "\033[1m"
     _ANSI_RESET = "\033[0m"
 
+    _SERVICE_WAIT_TIMEOUT_SEC = 5.0
+    _SERVICE_CALL_TIMEOUT_SEC = 10.0
+
     def _require_parameter(self, name: str) -> object:
         value = self.get_parameter(name).value
         if value is None:
@@ -491,10 +494,14 @@ class AutostartOrchestrator(Node):
 
         self._set_workflow_state(self._STATE_REQUEST_CONTROL_MODE, "initialization done")
 
-    def _wait_for_service(self, client) -> bool:
-        return client.wait_for_service()
+    def _wait_for_service(self, client, timeout_sec: float = _SERVICE_WAIT_TIMEOUT_SEC) -> bool:
+        try:
+            return bool(client.wait_for_service(timeout_sec=timeout_sec))
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().warn(f"wait_for_service failed: {exc}")
+            return False
 
-    def _call_trigger(self, client) -> tuple[bool, str]:
+    def _call_trigger(self, client, timeout_sec: float = _SERVICE_CALL_TIMEOUT_SEC) -> tuple[bool, str]:
         event = threading.Event()
         result: tuple[bool, str] = (False, "no_response")
 
@@ -511,7 +518,8 @@ class AutostartOrchestrator(Node):
                 event.set()
 
         future.add_done_callback(_done)
-        event.wait()
+        if not event.wait(timeout=timeout_sec):
+            return False, f"timeout after {timeout_sec}s"
         return result
 
     def _publish_control_mode(self) -> tuple[bool, str]:
@@ -520,7 +528,10 @@ class AutostartOrchestrator(Node):
 
         msg = Bool()
         msg.data = True
-        self._pub_control_mode.publish(msg)
+        try:
+            self._pub_control_mode.publish(msg)
+        except Exception as exc:  # noqa: BLE001
+            return False, f"publish failed: {exc}"
         return True, f"published to {topic} data={msg.data}"
 
     def _output_dir(self) -> Path:

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -538,7 +538,7 @@ class AutostartOrchestrator(Node):
         try:
             self._pub_control_mode.publish(msg)
         except Exception as exc:  # noqa: BLE001
-            return False, f"publish failed: {exc}"
+            return False, f"publish to {topic} failed: {exc}"
         return True, f"published to {topic} data={msg.data}"
 
     def _output_dir(self) -> Path:

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
@@ -76,11 +76,11 @@ class AwsimStateManager(Node):
         self._awsim_kill_patterns = self._split_csv(str(self.get_parameter("awsim_kill_patterns").value))
         self._debug_visualization_enabled = bool(self.get_parameter("enable_debug_visualization").value)
         self._debug_panel_queue: Optional[queue.Queue[_DashboardPayload]] = None
-        self._debug_panel_active = False
         self._debug_panel_error_logged = False
         self._debug_panel_thread: Optional[threading.Thread] = None
         self._debug_panel_stop_event: Optional[threading.Event] = None
         self._debug_panel_app: Optional[object] = None
+        self._debug_panel_qtcore: Optional[object] = None
         self._admin_state_topic = str(self.get_parameter("admin_state_topic").value).strip() or "/admin/awsim/state"
         self._admin_start_topic = str(self.get_parameter("admin_start_topic").value).strip() or self._DEFAULT_ADMIN_START_TOPIC
         self._admin_start_trigger_states = self._normalize_admin_state_list(
@@ -239,9 +239,10 @@ class AwsimStateManager(Node):
                 if not self._debug_panel_error_logged:
                     self.get_logger().warn(f"failed to import Qt binding for visualization: {exc}")
                     self._debug_panel_error_logged = True
-                self._debug_panel_active = False
                 self._debug_panel_queue = None
                 return
+
+            self._debug_panel_qtcore = QtCore
 
             class _DashboardWindow(QtWidgets.QWidget):
                 def __init__(self, awsim_states: tuple[str, ...]) -> None:
@@ -335,7 +336,6 @@ class AwsimStateManager(Node):
                     self._meta.setText("monitoring target: AWSIM process by pattern")
 
             self._debug_panel_queue = queue.Queue(maxsize=128)
-            self._debug_panel_active = True
 
             app = QtWidgets.QApplication.instance()
             if app is None:
@@ -366,7 +366,6 @@ class AwsimStateManager(Node):
 
             dashboard.show()
             app.exec()
-            self._debug_panel_active = False
             self._debug_panel_queue = None
             self._debug_panel_app = None
 
@@ -376,21 +375,13 @@ class AwsimStateManager(Node):
         self._debug_panel_thread.start()
 
     def _stop_debug_visualization(self) -> None:
-        self._debug_panel_active = False
         stop_event = self._debug_panel_stop_event
         if stop_event is not None:
             stop_event.set()
         app = self._debug_panel_app
-        if app is not None:
-            try:
-                from PySide6 import QtCore
-            except Exception:  # noqa: BLE001
-                try:
-                    from PyQt5 import QtCore
-                except Exception:  # noqa: BLE001
-                    QtCore = None
-            if QtCore is not None:
-                QtCore.QMetaObject.invokeMethod(app, "quit", QtCore.Qt.QueuedConnection)
+        qtcore = self._debug_panel_qtcore
+        if app is not None and qtcore is not None:
+            qtcore.QMetaObject.invokeMethod(app, "quit", qtcore.Qt.QueuedConnection)
         thread = self._debug_panel_thread
         if thread is not None and thread.is_alive():
             thread.join(timeout=1.0)
@@ -400,6 +391,7 @@ class AwsimStateManager(Node):
         self._debug_panel_thread = None
         self._debug_panel_queue = None
         self._debug_panel_app = None
+        self._debug_panel_qtcore = None
 
     @staticmethod
     def _is_alive(pid: int) -> bool:

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
@@ -386,6 +386,7 @@ class AwsimStateManager(Node):
         app = self._debug_panel_app
         qtcore = self._debug_panel_qtcore
         if app is not None and qtcore is not None:
+            # _on_timer 経由の quit は最大 250ms 遅延するので、Qt スレッドへ即時 quit をキューする保険。
             qtcore.QMetaObject.invokeMethod(app, "quit", qtcore.Qt.QueuedConnection)
         thread = self._debug_panel_thread
         if thread is not None and thread.is_alive():

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
@@ -78,6 +78,9 @@ class AwsimStateManager(Node):
         self._debug_panel_queue: Optional[queue.Queue[_DashboardPayload]] = None
         self._debug_panel_active = False
         self._debug_panel_error_logged = False
+        self._debug_panel_thread: Optional[threading.Thread] = None
+        self._debug_panel_stop_event: Optional[threading.Event] = None
+        self._debug_panel_app: Optional[object] = None
         self._admin_state_topic = str(self.get_parameter("admin_state_topic").value).strip() or "/admin/awsim/state"
         self._admin_start_topic = str(self.get_parameter("admin_start_topic").value).strip() or self._DEFAULT_ADMIN_START_TOPIC
         self._admin_start_trigger_states = self._normalize_admin_state_list(
@@ -223,7 +226,10 @@ class AwsimStateManager(Node):
             pass
 
     def _start_debug_visualization(self) -> None:
-        def _run() -> None:
+        self._debug_panel_stop_event = threading.Event()
+        self._debug_panel_app = None
+
+        def _run(stop_event: threading.Event) -> None:
             try:
                 try:
                     from PySide6 import QtCore, QtGui, QtWidgets
@@ -334,22 +340,24 @@ class AwsimStateManager(Node):
             app = QtWidgets.QApplication.instance()
             if app is None:
                 app = QtWidgets.QApplication(["awsim_state_manager"])
+            self._debug_panel_app = app
             dashboard = _DashboardWindow(
                 self._DEBUG_AWSIM_STATES,
             )
 
             def _on_timer() -> None:
-                if not self._debug_panel_active:
+                if stop_event.is_set():
+                    app.quit()
                     return
-                next_payload: Optional[_DashboardPayload] = None
+                latest: Optional[_DashboardPayload] = None
                 while True:
                     try:
-                        next_payload = self._debug_panel_queue.get_nowait()
+                        latest = self._debug_panel_queue.get_nowait()
                     except queue.Empty:
                         break
-                if next_payload is None:
+                if latest is None:
                     return
-                state, pids, now, admin_state = next_payload
+                state, pids, now, admin_state = latest
                 dashboard.update_state(state, pids, now, admin_state)
 
             timer = QtCore.QTimer()
@@ -360,8 +368,38 @@ class AwsimStateManager(Node):
             app.exec()
             self._debug_panel_active = False
             self._debug_panel_queue = None
+            self._debug_panel_app = None
 
-        threading.Thread(target=_run, daemon=True).start()
+        self._debug_panel_thread = threading.Thread(
+            target=_run, args=(self._debug_panel_stop_event,), daemon=True
+        )
+        self._debug_panel_thread.start()
+
+    def _stop_debug_visualization(self) -> None:
+        self._debug_panel_active = False
+        stop_event = self._debug_panel_stop_event
+        if stop_event is not None:
+            stop_event.set()
+        app = self._debug_panel_app
+        if app is not None:
+            try:
+                from PySide6 import QtCore
+            except Exception:  # noqa: BLE001
+                try:
+                    from PyQt5 import QtCore
+                except Exception:  # noqa: BLE001
+                    QtCore = None
+            if QtCore is not None:
+                QtCore.QMetaObject.invokeMethod(app, "quit", QtCore.Qt.QueuedConnection)
+        thread = self._debug_panel_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=1.0)
+            if thread.is_alive():
+                self.get_logger().warn("debug visualization thread did not exit within timeout")
+        self._debug_panel_stop_event = None
+        self._debug_panel_thread = None
+        self._debug_panel_queue = None
+        self._debug_panel_app = None
 
     @staticmethod
     def _is_alive(pid: int) -> bool:
@@ -641,6 +679,7 @@ class AwsimStateManager(Node):
             time.sleep(1.0)
 
     def destroy_node(self) -> bool:
+        self._stop_debug_visualization()
         if not self._shutdown_started and bool(self.get_parameter("shutdown_on_exit").value):
             self._shutdown_reason = "destroy_node"
             self._start_shutdown()

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py
@@ -337,37 +337,42 @@ class AwsimStateManager(Node):
 
             self._debug_panel_queue = queue.Queue(maxsize=128)
 
-            app = QtWidgets.QApplication.instance()
-            if app is None:
-                app = QtWidgets.QApplication(["awsim_state_manager"])
-            self._debug_panel_app = app
-            dashboard = _DashboardWindow(
-                self._DEBUG_AWSIM_STATES,
-            )
+            try:
+                app = QtWidgets.QApplication.instance()
+                if app is None:
+                    app = QtWidgets.QApplication(["awsim_state_manager"])
+                self._debug_panel_app = app
+                dashboard = _DashboardWindow(
+                    self._DEBUG_AWSIM_STATES,
+                )
 
-            def _on_timer() -> None:
-                if stop_event.is_set():
-                    app.quit()
-                    return
-                latest: Optional[_DashboardPayload] = None
-                while True:
-                    try:
-                        latest = self._debug_panel_queue.get_nowait()
-                    except queue.Empty:
-                        break
-                if latest is None:
-                    return
-                state, pids, now, admin_state = latest
-                dashboard.update_state(state, pids, now, admin_state)
+                def _on_timer() -> None:
+                    if stop_event.is_set():
+                        app.quit()
+                        return
+                    latest: Optional[_DashboardPayload] = None
+                    while True:
+                        try:
+                            latest = self._debug_panel_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                    if latest is None:
+                        return
+                    state, pids, now, admin_state = latest
+                    dashboard.update_state(state, pids, now, admin_state)
 
-            timer = QtCore.QTimer()
-            timer.timeout.connect(_on_timer)
-            timer.start(250)
+                timer = QtCore.QTimer()
+                timer.timeout.connect(_on_timer)
+                timer.start(250)
 
-            dashboard.show()
-            app.exec()
-            self._debug_panel_queue = None
-            self._debug_panel_app = None
+                dashboard.show()
+                app.exec()
+            except Exception as exc:  # noqa: BLE001
+                self.get_logger().warn(f"debug visualization worker crashed: {exc}")
+            finally:
+                self._debug_panel_queue = None
+                self._debug_panel_app = None
+                self._debug_panel_qtcore = None
 
         self._debug_panel_thread = threading.Thread(
             target=_run, args=(self._debug_panel_stop_event,), daemon=True


### PR DESCRIPTION
## Summary

`autostart_orchestrator_py` で発生し得る2系統のハング/リソースリークを修正する。

- **service 呼び出しのタイムアウト化**: `_wait_for_service` / `_call_trigger` / `_publish_control_mode` がタイムアウト無しに service 応答や context shutdown を待つ実装だったため、stuck Autoware や評価終了直後の publish でオーケストレータ全体が止まる経路があった。タイムアウトをクラス定数 `_SERVICE_WAIT_TIMEOUT_SEC=5.0` / `_SERVICE_CALL_TIMEOUT_SEC=10.0` に切り出し、`_call_trigger` 失敗時は `future.cancel()` で executor 追跡からも外す。
- **AWSIM デバッグ Qt パネルのライフサイクル化**: `_start_debug_visualization` の Qt スレッドが `daemon=True` 任せで停止経路を持たず、`destroy_node` 後にウィンドウが残る・スレッドリークするケースがあった。`threading.Event` + `QMetaObject.invokeMethod(app, "quit", QueuedConnection)` の二段構えで Qt スレッドへ停止指示を送り、`destroy_node` から `_stop_debug_visualization()` を呼んで 1 秒 join。worker 内部は `try/except/finally` で QApplication / queue / QtCore 参照を例外パスでも確実にクリアする。
- 副次的に dead state `_debug_panel_active` を削除し、停止判定を `stop_event` に一本化。

## なぜ必要か

- 評価コンテナを Ctrl-C / `docker stop` で落とした際に Qt サブウィンドウとスレッドが残留し、次回 `make dev` で再現性が落ちる事象があった。
- Autoware 側が前段で死んでいると `_call_trigger` が無限待ちになり、`autostart_orchestrator` の状態遷移が止まる。

## 主な変更ファイル

- `aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py` (+19/-7)
- `aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/awsim_state_manager_node.py` (+72/-32)
- `design_docs/autostart_orchestrator_shutdown_hardening.md` (new, 設計記録)

## Test plan

- [ ] `make autoware-build` — コンパイルが通る
- [ ] `make dev` → `make autoware-simulator` で初期化完了し、`published to ... data=True` がログに出る（healthy ケース）
- [ ] Autoware service を意図的に止めた状態で起動 → `wait_for_service failed` が 5s で warn 出力、ハングしない
- [ ] Trigger 応答を返さないモックで `_call_trigger` を駆動 → 10s で `timeout after 10.0s` を返し、`future.cancel()` 経由で executor の追跡が解放される
- [ ] `make dev` 中に Ctrl-C → Qt パネルがクリーンに閉じ、`debug visualization thread did not exit within timeout` warn が出ない
- [ ] `run_evaluation.bash` 一周 → 評価スコアが正常に出る（タイムアウト経路が healthy 系で誤発火しない）
- [ ] `pre-commit run -a` がパス