### PR TITLE
fix: mount cyclonedds.xml instead of copy in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ ENV ROS_LOCALHOST_ONLY=0
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV CYCLONEDDS_URI=file:///opt/autoware/cyclonedds.xml
 
-COPY vehicle/cyclonedds.xml /opt/autoware/cyclonedds.xml
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ ENV ROS_LOCALHOST_ONLY=0
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ENV CYCLONEDDS_URI=file:///opt/autoware/cyclonedds.xml
 
-
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/v2x_marker_publisher.py
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/v2x_marker_publisher.py
@@ -8,10 +8,10 @@ from v2x_msgs.msg import V2XVehiclePositionArray
 
 
 VEHICLE_COLORS = {
-    "d1": (1.0, 0.2, 0.2),
-    "d2": (0.2, 1.0, 0.2),
-    "d3": (0.2, 0.4, 1.0),
-    "d4": (1.0, 0.9, 0.2),
+    "d1": (0.2, 0.4, 1.0),
+    "d2": (1.0, 0.9, 0.2),
+    "d3": (0.2, 1.0, 0.2),
+    "d4": (1.0, 0.2, 0.2),
 }
 DEFAULT_COLOR = (1.0, 1.0, 1.0)
 SPHERE_DIAMETER = 1.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ x-autoware-base: &autoware-base
     - ./aichallenge:/aichallenge
     - ./remote:/remote
     - ./vehicle:/vehicle
+    - ./vehicle/cyclonedds.xml:/opt/autoware/cyclonedds.xml
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
     # Audio (PipeWire/Pulse) socket access on the host
     - /run/user:/run/user:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ x-autoware-eval-base: &autoware-eval-base
     - ./output:${OUTPUT_ROOT:-/output}
     # /aichallenge is baked into the eval image; intentionally not mounted here
     # - ./aichallenge:/aichallenge
+    - ./vehicle/cyclonedds.xml:/opt/autoware/cyclonedds.xml
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
     # Audio (PipeWire/Pulse) socket access on the host
     - /run/user:/run/user:rw

--- a/setup.bash
+++ b/setup.bash
@@ -243,7 +243,7 @@ Usage:
   ./setup.bash pull image     # docker pull Autoware base image (recommended)
   ./setup.bash download awsim # download & extract AWSIM.zip (repo-local)
   ./setup.bash env            # create .env from .env.example (safe, repo-local)
-  ./setup.bash network-if <name>
+  ./setup.bash network-if [name]
                             # add network interface to cyclonedds.xml
   ./setup.bash network-if   # remove all ai-challenge-added interfaces from cyclonedds.xml
   ./setup.bash bootstrap --yes
@@ -1090,7 +1090,7 @@ _network_if_edit_file() {
         fi
     fi
 
-    if ! confirm_step "${file} を書き換えますか？"; then
+    if ! confirm_step "Overwrite ${file}?"; then
         log "${INFO} Skipped: ${file}"
         return 0
     fi
@@ -1100,7 +1100,7 @@ _network_if_edit_file() {
 
     if [ -n "${iface}" ]; then
         if grep -qF "name=\"${iface}\"" "${file}"; then
-            log "${INFO} '${iface}' は既に存在します: ${file}"
+            log "${INFO} '${iface}' already exists in ${file}"
             return 0
         fi
         if ! ${sed_cmd} -i "/<\/Interfaces>/i\\        <NetworkInterface autodetermine=\"false\" name=\"${iface}\" priority=\"default\" multicast=\"default\" /> <!-- added by ai-challenge -->" "${file}"; then
@@ -1120,6 +1120,16 @@ _network_if_edit_file() {
 add_network_interface() {
     local iface="${1-}"
 
+    if [ -n "${iface}" ]; then
+        if ! [[ ${iface} =~ ^[A-Za-z0-9._-]+$ ]]; then
+            warn "${FAIL} Invalid interface name: ${iface}"
+            return 1
+        fi
+        if cmd_exists ip && ! ip link show "${iface}" >/dev/null 2>&1; then
+            warn "${WARN} Interface '${iface}' not found on this host (Autoware may fail to start)"
+        fi
+    fi
+
     local xml_vehicle="${REPO_ROOT:-.}/vehicle/cyclonedds.xml"
 
     local uri_file=""
@@ -1127,6 +1137,9 @@ add_network_interface() {
         case "${CYCLONEDDS_URI}" in
         file://*)
             uri_file="${CYCLONEDDS_URI#file://}"
+            ;;
+        *)
+            log "${INFO} CYCLONEDDS_URI is set but not a file:// URI, skipping: ${CYCLONEDDS_URI}"
             ;;
         esac
     fi

--- a/setup.bash
+++ b/setup.bash
@@ -1118,12 +1118,12 @@ _network_if_edit_file() {
 }
 
 add_network_interface() {
-    local iface="${1:-}"
+    local iface="${1-}"
 
     local xml_vehicle="${REPO_ROOT:-.}/vehicle/cyclonedds.xml"
 
     local uri_file=""
-    if [ -n "${CYCLONEDDS_URI:-}" ]; then
+    if [ -n "${CYCLONEDDS_URI-}" ]; then
         case "${CYCLONEDDS_URI}" in
         file://*)
             uri_file="${CYCLONEDDS_URI#file://}"

--- a/setup.bash
+++ b/setup.bash
@@ -243,6 +243,9 @@ Usage:
   ./setup.bash pull image     # docker pull Autoware base image (recommended)
   ./setup.bash download awsim # download & extract AWSIM.zip (repo-local)
   ./setup.bash env            # create .env from .env.example (safe, repo-local)
+  ./setup.bash network-if <name>
+                            # add network interface to cyclonedds.xml
+  ./setup.bash network-if   # remove all ai-challenge-added interfaces from cyclonedds.xml
   ./setup.bash bootstrap --yes
                             # non-interactive bootstrap (auto-yes)
   ./setup.bash bootstrap --temp-dir [--keep-dir]
@@ -1068,6 +1071,80 @@ doctor() {
     return "$failed"
 }
 
+_network_if_edit_file() {
+    local file="$1"
+    local iface="$2"
+
+    if [ ! -f "${file}" ]; then
+        log "${INFO} Skipped (not found): ${file}"
+        return 0
+    fi
+
+    local use_sudo=0
+    if [ ! -w "${file}" ]; then
+        if cmd_exists sudo; then
+            use_sudo=1
+        else
+            warn "${WARN} Write permission denied and sudo not available, skipping: ${file}"
+            return 0
+        fi
+    fi
+
+    if ! confirm_step "${file} を書き換えますか？"; then
+        log "${INFO} Skipped: ${file}"
+        return 0
+    fi
+
+    local sed_cmd="sed"
+    [ "${use_sudo}" -eq 1 ] && sed_cmd="sudo sed"
+
+    if [ -n "${iface}" ]; then
+        if grep -qF "name=\"${iface}\"" "${file}"; then
+            log "${INFO} '${iface}' は既に存在します: ${file}"
+            return 0
+        fi
+        if ! ${sed_cmd} -i "/<\/Interfaces>/i\\        <NetworkInterface autodetermine=\"false\" name=\"${iface}\" priority=\"default\" multicast=\"default\" /> <!-- added by ai-challenge -->" "${file}"; then
+            warn "${FAIL} Failed to edit (permission denied?): ${file}"
+            return 0
+        fi
+        log "${OK} Added '${iface}' to ${file}"
+    else
+        if ! ${sed_cmd} -i '/<!-- added by ai-challenge -->/d' "${file}"; then
+            warn "${FAIL} Failed to edit (permission denied?): ${file}"
+            return 0
+        fi
+        log "${OK} Removed ai-challenge entries from ${file}"
+    fi
+}
+
+add_network_interface() {
+    local iface="${1:-}"
+
+    local xml_vehicle="${REPO_ROOT:-.}/vehicle/cyclonedds.xml"
+
+    local uri_file=""
+    if [ -n "${CYCLONEDDS_URI:-}" ]; then
+        case "${CYCLONEDDS_URI}" in
+        file://*)
+            uri_file="${CYCLONEDDS_URI#file://}"
+            ;;
+        esac
+    fi
+
+    _network_if_edit_file "${xml_vehicle}" "${iface}"
+
+    if [ -n "${uri_file}" ]; then
+        local v_real u_real
+        v_real="$(realpath "${xml_vehicle}" 2>/dev/null || echo "${xml_vehicle}")"
+        u_real="$(realpath "${uri_file}" 2>/dev/null || echo "${uri_file}")"
+        if [ "${v_real}" = "${u_real}" ]; then
+            log "${INFO} Skipped (same file as vehicle/cyclonedds.xml): ${uri_file}"
+        else
+            _network_if_edit_file "${uri_file}" "${iface}"
+        fi
+    fi
+}
+
 main() {
     if [ $# -eq 0 ]; then
         if [ -n "$REPO_ROOT" ]; then
@@ -1110,6 +1187,10 @@ main() {
         ;;
     env)
         ensure_env
+        ;;
+    network-if)
+        shift
+        add_network_interface "$@"
         ;;
     download)
         case "${2-}" in

--- a/vehicle/cyclonedds.xml
+++ b/vehicle/cyclonedds.xml
@@ -3,7 +3,7 @@
   <Domain Id="any">
     <General>
       <Interfaces>
-	      <NetworkInterface autodetermine="false" name="lo" priority="default" multicast="default" />
+        <NetworkInterface autodetermine="false" name="lo" priority="default" multicast="default" />
       </Interfaces>
       <AllowMulticast>default</AllowMulticast>
       <MaxMessageSize>65500B</MaxMessageSize>


### PR DESCRIPTION
## 概要

- 現状の問題1
  - sim決勝等で、AWSIMが動いている外部PCに接続するためには、Host PCとDockerコンテナ両方の`cyclonedds.xml`に `<NetworkInterface>` を追加する必要があります
  - しかし、現状はDocker Build時にコピーしているため、設定反映ミスが生じやすいです。また、同じ設定をHostとコンテナの両方にする必要があるため、手間がかかります
- 現状の問題2（ついでの変更）
  - 各車両を表す色が、AWSIMとrvizで異なります

## 変更
- 問題1への対応
  - cyclonedds.xmlをコピーする代わりにマウントします
  - ./setup.bashにcyclonedds.xmlにインターフェイスを追加・削除するコマンドを追加します
- 問題2への対応
  - rvizで表示する色をAWSIMに合わせて以下のようにします
  - P1=青、P2=黄、P3=緑、P4=赤にして

## テスト

注意：テストする前に、一度だけ `./docker_build.sh dev` が必要です

- `pre-commit run -a` がパスすること
- `./setup.bash network-if enp4s0` を実行して、以下の2つのcyclonedds.xmlファイルに以下が追加されること
  - `<NetworkInterface autodetermine="false" name="enp4s0" priority="default" multicast="default" /> <!-- added by ai-challenge -->`
  - ファイル1: `./vehicle/cyclonedds.xml`
  - ファイル2: ホスト環境の `${CYCLONEDDS_URI}` で指定された`cyclonedds.xml`
- `make dev` で起動して、autowareコンテナの `/opt/autoware/cyclonedds.xml` にも反映されていること
  - `enp4s0` は例です。存在しないインターフェイスを指定するとAutowareの起動に失敗する可能性があります
- `./setup.bash network-if` を実行して、先程の2つのcyclonedds.xmlが元に戻っていること
- `make eval`でも同様の挙動をすること
- `make dev4` で起動したとき、AWSIMと各rvizで表示される車両の色が同じであること


<img width="1352" height="728" alt="image" src="https://github.com/user-attachments/assets/0d21a4f3-b460-4861-9106-dd03e24c3957" />
