### PR TITLE
fix: disable raw_vehicle_cmd_converter when simulation mode

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
@@ -4,7 +4,7 @@
     <arg name="use_sim_time"/>
     <arg name="run_rviz"/>
     <arg name="sensor_model" default="racing_kart_sensor_kit"/>
-    <arg name="launch_vehicle_interface" default="true"/>
+    <arg name="launch_vehicle_interface" default="$(eval &quot;'$(var simulation)' == 'false'&quot;)"/>
     <arg name="capture" default="false"/>
     <arg name="rosbag" default="false"/>
     <arg name="domain_id" default="0"/>


### PR DESCRIPTION
## 背景・問題

- 従来（2025年まで）は、下記図のように、`control_cmd`を、`raw_vehicle_cmd_converter`で`actuation_cmd`に変換し、さらに`actuation_cmd_converter`で`control_cmd`に戻してからAWSIMに入力していました
  - <img width="485" height="578" alt="image" src="https://github.com/user-attachments/assets/bd210b91-d393-4217-8648-8d92b3b5c75c" />
- 2026年からは、`control_cmd`を直接AWSIMに入力するようになりました。そのため、`raw_vecle_cmd_converter`は車両環境のみで必要で、シミュレーション環境では不要になります。
- <img width="923" height="608" alt="image" src="https://github.com/user-attachments/assets/e183849f-3c2f-4390-a0f8-1b43180ca86a" />

- しかし現状、`make dev` でAWSIM環境で実行しても`raw_vecle_cmd_converter`ノードが存在します
- 原因は、最上位のlaunchである`aichallenge_system.launch.xml`で`launch_vehicle_interface`に`true`を設定しているためです
  - 下位のlaunchでは、`simulation=true`のときにfalseにするようにしているが、上位のdefault値であるtrueが優先されていました

## 変更・修正

- `aichallenge_system.launch.xml`の`launch_vehicle_interface`の初期値を修正しました

## テスト

- `make dev`, `make autoware-simulator` , `make dev4` で起動した後、autowareコンテナ内で `ros2 node list` を入力して、 `/raw_vehicle_cmd_converter` が存在しないこと。AWSIM上で車両が問題なく走行できること
- `maek autoware-vehicle` で起動した後、autowareコンテナ内で `ros2 node list` を入力して、 `/raw_vehicle_cmd_converter` が存在すること
