### PR TITLE
fix!: mount cyclonedds.xml for rocker

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -6,10 +6,10 @@ device_drivers="/dev/dri"
 
 case "${target}" in
 "eval")
-    volume="output:/output /run/user:/run/user:rw"
+    volume="output:/output vehicle/cyclonedds.xml:/opt/autoware/cyclonedds.xml /run/user:/run/user:rw"
     ;;
 "dev")
-    volume="output:/output aichallenge:/aichallenge remote:/remote vehicle:/vehicle /dev/input:/dev/input /run/user:/run/user:rw"
+    volume="output:/output aichallenge:/aichallenge remote:/remote vehicle:/vehicle vehicle/cyclonedds.xml:/opt/autoware/cyclonedds.xml /dev/input:/dev/input /run/user:/run/user:rw"
     ;;
 "rm")
     # clean up old <none> images


### PR DESCRIPTION
## 背景

- https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/206 で、cyclonedds.xmlをDockerイメージビルド時にコピーするのではなく、実行時にマウントするように変更しました
- しかし、 `./docker_run.sh` から実行されるrockerでは対応が漏れていました

## 変更

- `./docker_run.sh` のvolume設定にcyclonedds.xmlを追加しました

## テスト

- dev、evalの両方で以下を確認しました。コマンドは後述
  - cyclonedds.xmlが正しくマウントされていること
  - 走行開始できること

```
make simulator
./docker_run.sh dev
# 以下、rocker内
cat /opt/autoware/cyclonedds.xml   # ファイルが正しいこと
export ROS_DOMAIN_ID=1
./run_autoware.bash awsim             # 走行開始すること
```


```
./docker_run.sh eval
# 以下、rocker内
cat /opt/autoware/cyclonedds.xml   # ファイルが正しいこと
/aichallenge/run_evaluation.bash    # 走行開始すること
```
