### PR TITLE
fix: retry zenoh bridge on connection failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   zenoh:
     <<: *autoware-base
     working_dir: /vehicle
-    command: ["bash", "-lc", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac; while true; do zenoh-bridge-ros2dds client -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:$$PORT -c /vehicle/zenoh.json5; status=$$?; echo \"zenoh-bridge-ros2dds exited with status $$status; retrying in $${ZENOH_RETRY_INTERVAL:-5}s...\"; sleep $${ZENOH_RETRY_INTERVAL:-5}; done"]
+    command: ["bash", "-lc", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac; while true; do zenoh-bridge-ros2dds client -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:$$PORT -c /vehicle/zenoh.json5; status=$$?; echo \"zenoh-bridge-ros2dds exited with status $$status; retrying in 5s...\"; sleep 5; done"]
 
   # Driver service
   driver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   zenoh:
     <<: *autoware-base
     working_dir: /vehicle
-    command: ["bash", "-lc", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac; while true; do zenoh-bridge-ros2dds client -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:$$PORT -c /vehicle/zenoh.json5; status=$$?; echo \"zenoh-bridge-ros2dds exited with status $$status; retrying in 5s...\"; sleep 5; done"]
+    command: ["bash", "-c", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac; while true; do zenoh-bridge-ros2dds client -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:$$PORT -c /vehicle/zenoh.json5; status=$$?; echo \"zenoh-bridge-ros2dds exited with status $$status; retrying in 5s...\"; sleep 5; done"]
 
   # Driver service
   driver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   zenoh:
     <<: *autoware-base
     working_dir: /vehicle
-    command: ["bash", "-c", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac && zenoh-bridge-ros2dds client -e tls/13.231.141.103:$$PORT -c /vehicle/zenoh.json5"]
+    command: ["bash", "-lc", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac; while true; do zenoh-bridge-ros2dds client -e tls/13.231.141.103:$$PORT -c /vehicle/zenoh.json5; status=$$?; echo \"zenoh-bridge-ros2dds exited with status $$status; retrying in $${ZENOH_RETRY_INTERVAL:-5}s...\"; sleep $${ZENOH_RETRY_INTERVAL:-5}; done"]
 
   # Driver service
   driver:


### PR DESCRIPTION
## 概要
- zenoh bridge が終了した場合にコンテナ内で再起動を5秒おきに試行するようにしました

- インターネットに接続していない状態でmake zenohするとドメインの名前解決ができずにzenoh_bridge_ros2ddsが終了し、そのあとにインターネットに接続してもプロセスが終了しているため再試行しない状態だった。
※1回接続したあとの、切断からの再接続は修正前でもやってくれていた。
```
2026-05-31T15:09:23.258799Z  INFO tokio-runtime-worker ThreadId(19) zenoh_plugin_ros2dds: ROS2 plugin Config { namespace: "/", nodename: "zenoh_bridge_ros2dds", domain: 1, ros_localhost_only: false, ros_automatic_discovery_range: None, ros_static_peers: None, allowance: Some(Allow(ROS2InterfacesRegex { publishers: Some(Regex("^/control/command/control_cmd$|^/localization/kinematic_state$|^/planning/scenario_planning/trajectory$|^/tf$|^/tf_static$|^/vehicle/status/gear_status$|^/vehicle/status/steering_status$|^/vehicle/status/velocity_status$")), subscribers: Some(Regex("^/racing_kart/joy$|^/initialpose$")), service_servers: None, service_clients: None, action_servers: None, action_clients: None })), pub_max_frequencies: [(Regex("/*"), 10.0)], transient_local_cache_multiplier: 10, queries_timeout: Some(QueriesTimeouts { default: 2.0, transient_local_subscribers: [], services: [], actions: Some(ActionsTimeouts { send_goal: [], cancel_goal: [], get_result: [(Regex(".*"), 300.0)] }) }), reliable_routes_blocking: false, pub_priorities: [(Regex("/control/command/control_cmd"), (Background, false)), (Regex("/localization/kinematic_state"), (Data, false)), (Regex("/planning/scenario_planning/trajectory"), (Background, false)), (Regex("/tf"), (Background, false)), (Regex("/tf_static"), (Background, false)), (Regex("/vehicle/status/gear_status"), (Background, false)), (Regex("/vehicle/status/steering_status"), (Background, false)), (Regex("/vehicle/status/velocity_status"), (Background, false))], work_thread_num: 2, max_block_thread_num: 50, __required__: None, __path__: None }
2026-05-31T15:09:23.259864Z  WARN                 main ThreadId(01) zenoh::net::runtime::orchestrator: Unable to connect to tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454! failed to lookup address information: Temporary failure in name resolution
2026-05-31T15:09:23.259880Z  WARN                 main ThreadId(01) zenoh::net::runtime::orchestrator: Unable to connect to any of [tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.5.0/src/net/runtime/orchestrator.rs:367.
Failed to start Zenoh runtime: Unable to connect to any of [tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.5.0/src/net/runtime/orchestrator.rs:367.. Exiting...
```

## Test

5secおきに接続を試みていることを確認。
```
_status"), (Background, false)), (Regex("/vehicle/status/velocity_status"), (Background, false))], work_thread_num: 2, max_block_thread_num: 50, __required__: None, __path__: None }
2026-05-31T15:05:29.856085Z  WARN                 main ThreadId(01) zenoh::net::runtime::orchestrator: Unable to connect to tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454! failed to lookup address information: Temporary failure in name resolution
2026-05-31T15:05:29.856109Z  WARN                 main ThreadId(01) zenoh::net::runtime::orchestrator: Unable to connect to any of [tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.5.0/src/net/runtime/orchestrator.rs:367.
Failed to start Zenoh runtime: Unable to connect to any of [tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.5.0/src/net/runtime/orchestrator.rs:367.. Exiting...
zenoh-bridge-ros2dds exited with status 255; retrying in 5s...
```

インターネットに接続したら、接続が成功することを確認
```
2026-05-31T15:05:44.918654Z  WARN                 main ThreadId(01) zenoh::net::runtime::orchestrator: Unable to connect to any of [tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.5.0/src/net/runtime/orchestrator.rs:367.
Failed to start Zenoh runtime: Unable to connect to any of [tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.5.0/src/net/runtime/orchestrator.rs:367.. Exiting...
zenoh-bridge-ros2dds exited with status 255; retrying in 5s...
2026-05-31T15:05:49.943359Z  INFO main ThreadId(01) zenoh_bridge_ros2dds: zenoh-bridge-ros2dds v1.5.0
2026-05-31T15:05:49.943902Z  INFO main ThreadId(01) zenoh_bridge_ros2dds: Zenoh Config(Config { id: None, metadata: Null, mode: Some(Client), connect: ConnectConfig { timeout_ms: None, endpoints: Unique([tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454]), exit_on_failure: None, retry: None }, listen: ListenConfig { timeout_ms: None, endpoints: Dependent(ModeValues { router: Some([tcp/[::]:7447]), peer: Some([tcp/[::]:0]), client: None }), exit_on_failure: None, retry: None }, open: OpenConf { return_conditions: ReturnConditionsConf { connect_scouted: None, declares: None } }, scouting: ScoutingConf { timeout: None, delay: None, multicast: ScoutingMulticastConf { enabled: None, address: None, interface: None, ttl: None, autoconnect: None, autoconnect_strategy: None, listen: None }, gossip: GossipConf { enabled: None, multihop: None, target: None, autoconnect: None, autoconnect_strategy: None } }, timestamping: TimestampingConf { enabled: Some(Unique(true)), drop_future_timestamp: None }, queries_default_timeout: None, routing: RoutingConf { router: RouterRoutingConf { peers_failover_brokering: None, linkstate: LinkstateConf { transport_weights: [] } }, peer: PeerRoutingConf { mode: None, linkstate: LinkstateConf { transport_weights: [] } }, interests: InterestsConf { timeout: None } }, aggregation: AggregationConf { subscribers: [], publishers: [] }, qos: QoSConfig { publication: PublisherQoSConfList([]), network: [] }, transport: TransportConf { unicast: TransportUnicastConf { open_timeout: 10000, accept_timeout: 10000, accept_pending: 100, max_sessions: 1000, max_links: 1, lowlatency: false, qos: QoSUnicastConf { enabled: true }, compression: CompressionUnicastConf { enabled: true } }, multicast: TransportMulticastConf { join_interval: Some(2500), max_sessions: Some(1000), qos: QoSMulticastConf { enabled: false }, compression: CompressionMulticastConf { enabled: true } }, link: TransportLinkConf { protocols: None, tx: LinkTxConf { sequence_number_resolution: U32, lease: 10000, keep_alive: 4, batch_size: 65535, queue: QueueConf { size: QueueSizeConf { control: 2, real_time: 2, interactive_high: 2, interactive_low: 2, data_high: 2, data: 2, data_low: 2, background: 2 }, congestion_control: CongestionControlConf { drop: CongestionControlDropConf { wait_before_drop: 1000, max_wait_before_drop_fragments: 50000 }, block: CongestionControlBlockConf { wait_before_close: 5000000 } }, batching: BatchingConf { enabled: true, time_limit: 1 }, allocation: QueueAllocConf { mode: Lazy } }, threads: 5 }, rx: LinkRxConf { buffer_size: 65535, max_message_size: 1073741824 }, tls: TLSConf { root_ca_certificate: Some("/remote/tls/server/minica.pem"), listen_private_key: None, listen_certificate: None, enable_mtls: Some(true), connect_private_key: Some("/remote/tls/client/key.pem"), connect_certificate: Some("/remote/tls/client/cert.pem"), verify_name_on_connect: None, close_link_on_expiration: Some(true), so_sndbuf: None, so_rcvbuf: None, root_ca_certificate_base64: None, listen_private_key_base64: None, listen_certificate_base64: None, connect_private_key_base64: None, connect_certificate_base64: None }, tcp: TcpConf { so_sndbuf: None, so_rcvbuf: None }, unixpipe: UnixPipeConf { file_access_mask: None } }, shared_memory: ShmConf { enabled: true, mode: Lazy }, auth: AuthConf { usrpwd: UsrPwdConf { user: None, password: None, dictionary_file: None }, pubkey: PubKeyConf { public_key_pem: None, private_key_pem: None, public_key_file: None, private_key_file: None, key_size: None, known_keys_file: None } } }, adminspace: AdminSpaceConf { enabled: true, permissions: PermissionsConf { read: true, write: false } }, namespace: None, downsampling: [], access_control: AclConfig { enabled: false, default_permission: Deny, rules: None, subjects: None, policies: None }, low_pass_filter: [], plugins_loading: PluginsLoading { enabled: true, search_dirs: LibSearchDirs([Spec(LibSearchSpec { kind: CurrentExeParent, value: None }), Path("."), Path("~/.zenoh/lib"), Path("/opt/homebrew/lib"), Path("/usr/local/lib"), Path("/usr/lib")]) }, plugins: Object {"ros2dds": Object {"allow": Object {"action_clients": Array [], "action_servers": Array [], "publishers": Array [String("/control/command/control_cmd"), String("/localization/kinematic_state"), String("/planning/scenario_planning/trajectory"), String("/tf"), String("/tf_static"), String("/vehicle/status/gear_status"), String("/vehicle/status/steering_status"), String("/vehicle/status/velocity_status")], "service_clients": Array [], "service_servers": Array [], "subscribers": Array [String("/racing_kart/joy"), String("/initialpose")]}, "domain": Number(1), "pub_max_frequencies": Array [String("/*=10")], "pub_priorities": Array [String("/control/command/control_cmd=7"), String("/localization/kinematic_state=5"), String("/planning/scenario_planning/trajectory=7"), String("/tf=7"), String("/tf_static=7"), String("/vehicle/status/gear_status=7"), String("/vehicle/status/steering_status=7"), String("/vehicle/status/velocity_status=7")], "queries_timeout": Object {"default": Number(2.0)}, "reliable_routes_blocking": Bool(false), "ros_localhost_only": Bool(false)}} })
2026-05-31T15:05:49.943953Z  INFO main ThreadId(01) zenoh::net::runtime: Using ZID: b3017a4f18bbecdc8169488ebcd5447
2026-05-31T15:05:49.944076Z  INFO main ThreadId(01) zenoh::api::loader: Starting required plugin "ros2dds"
2026-05-31T15:05:49.944336Z  INFO main ThreadId(01) zenoh::api::loader: Successfully started plugin ros2dds from "__static_lib__"
```


