### PR TITLE
fix: use domain name for Zenoh endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   zenoh:
     <<: *autoware-base
     working_dir: /vehicle
-    command: ["bash", "-c", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac && zenoh-bridge-ros2dds client -e tls/13.231.141.103:$$PORT -c /vehicle/zenoh.json5"]
+    command: ["bash", "-c", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac && zenoh-bridge-ros2dds client -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:$$PORT -c /vehicle/zenoh.json5"]
 
   # Driver service
   driver:

--- a/remote/connect_zenoh.bash
+++ b/remote/connect_zenoh.bash
@@ -13,43 +13,43 @@ case "$NAMESPACE" in
 A2)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-01) - Port 7448"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7448 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7448 \
         -c zenoh-user.json5
     ;;
 A3)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-02) - Port 7449"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7449 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7449 \
         -c zenoh-user.json5
     ;;
 A6)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-06) - Port 7450"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7450 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7450 \
         -c zenoh-user.json5
     ;;
 A7)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-00) - Port 7451"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7451 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7451 \
         -c zenoh-user.json5
     ;;
 A1)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' - Port 7452"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7452 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7452 \
         -c zenoh-user.json5
     ;;
 A5)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' - Port 7453"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7453 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7453 \
         -c zenoh-user.json5
     ;;
 A8)
     echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' - Port 7454"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/13.231.141.103:7454 \
+        -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:7454 \
         -c zenoh-user.json5
     ;;
 test-remote)


### PR DESCRIPTION
## Description
Zenoh router の接続先を IP 指定からドメイン指定に変更します。
車両と遠隔PC側では以下のtls証明書を車両のremote配下に置けばOK。
https://drive.google.com/drive/folders/11rEPswPEkNSzCvjXblADz0tvQ7IXGbf1?usp=drive_link

router側はこちらを配置
https://drive.google.com/drive/folders/1FvMu7ivSdgCT408iYMPhwMLZMxnavUBA
https://drive.google.com/file/d/1yNoHRVpPn-CyCENg0v5sB89CtK_vbqeX/view?usp=drive_link

## Test
手元で2つの異なるROS_DOMAIN_IDのネットワークを作って、/racing_kart/joyトピックが疎通することを確認