### PR TITLE
fix: add driver and Zenoh log files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,9 @@ rviz2:
 
 # driver + autoware + zenoh
 autoware-driver-zenoh:
-	RUN_MODE=vehicle docker compose up -d driver autoware
+	LOG_DIR=$(LOG_DIR) RUN_MODE=vehicle docker compose up -d driver autoware
 	sleep 15
-	docker compose up -d zenoh
+	LOG_DIR=$(LOG_DIR) docker compose up -d zenoh
 
 down:
 	@for p in 1 2 3 4; do docker compose -p $$p down --remove-orphans; done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,15 @@ x-racing_kart_interface-base: &racing_kart_interface-base
     - TZ=Asia/Tokyo
     - ROS_DISTRO=humble
     - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-1}
+    - LOG_DIR=${LOG_DIR:-}
+    - HOST_UID=${HOST_UID:-}
+    - HOST_GID=${HOST_GID:-}
     - NTRIP_USERNAME=${NTRIP_USERNAME:-}
     - NTRIP_PASSWORD=${NTRIP_PASSWORD:-}
   volumes:
+    - ./output:${OUTPUT_ROOT:-/output}
+    - ./vehicle:/vehicle:ro
+    - ./aichallenge/utils:/aichallenge/utils:ro
     - /dev/vcu:/dev/vcu
     - /dev/gnss:/dev/gnss
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
@@ -125,12 +131,13 @@ services:
   zenoh:
     <<: *autoware-base
     working_dir: /vehicle
-    command: ["bash", "-c", "case ${VEHICLE_ID:-} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; A1) PORT=7452;; A5) PORT=7453;; A8) PORT=7454;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac; while true; do zenoh-bridge-ros2dds client -e tls/zenoh.dev.aichallenge-board.jsae.or.jp:$$PORT -c /vehicle/zenoh.json5; status=$$?; echo \"zenoh-bridge-ros2dds exited with status $$status; retrying in 5s...\"; sleep 5; done"]
+    command: ["bash", "-lc", "exec /vehicle/run_zenoh.bash ${VEHICLE_ID:-} ${ROS_DOMAIN_ID:-1} ${LOG_DIR:-}"]
 
   # Driver service
   driver:
     <<: *racing_kart_interface-base
-    command: ['vehicle']
+    entrypoint: []
+    command: ["bash", "-lc", "exec /vehicle/run_driver.bash vehicle ${ROS_DOMAIN_ID:-1} ${LOG_DIR:-}"]
 
 #### remote visualization services ####
   rviz2:

--- a/vehicle/run_driver.bash
+++ b/vehicle/run_driver.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mode="${1}"
+id="${2:-${ROS_DOMAIN_ID:-0}}"
+out_dir="${3:+${3}/d${id}}"
+out_dir="${out_dir:-/output/$(date +%Y%m%d-%H%M%S)/d${id}}"
+
+export ROS_DOMAIN_ID=$id
+
+mkdir -p "${out_dir}"
+exec >"${out_dir}/driver.log" 2>&1
+trap 'bash /aichallenge/utils/fix_ownership.bash "${HOST_UID}" "${HOST_GID}" /output "$(dirname "${out_dir}")"' EXIT
+
+cd "${out_dir}" || exit
+export ROS_HOME="${out_dir}/ros"
+export ROS_LOG_DIR="${ROS_HOME}/log"
+mkdir -p "${ROS_LOG_DIR}"
+
+/entrypoint.sh "${mode}" "${@:4}"

--- a/vehicle/run_zenoh.bash
+++ b/vehicle/run_zenoh.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+vehicle_id="${1}"
+id="${2:-${ROS_DOMAIN_ID:-0}}"
+out_dir="${3:+${3}/d${id}}"
+out_dir="${out_dir:-/output/$(date +%Y%m%d-%H%M%S)/d${id}}"
+
+case "${vehicle_id}" in
+A2) PORT=7448 ;;
+A3) PORT=7449 ;;
+A6) PORT=7450 ;;
+A7) PORT=7451 ;;
+A1) PORT=7452 ;;
+A5) PORT=7453 ;;
+A8) PORT=7454 ;;
+*)
+    echo "Invalid VEHICLE_ID"
+    exit 1
+    ;;
+esac
+
+export ROS_DOMAIN_ID=$id
+
+mkdir -p "${out_dir}"
+exec >"${out_dir}/zenoh.log" 2>&1
+trap 'bash /aichallenge/utils/fix_ownership.bash "${HOST_UID}" "${HOST_GID}" /output "$(dirname "${out_dir}")"' EXIT
+
+cd "${out_dir}" || exit
+
+while true; do
+    zenoh-bridge-ros2dds client -e "tls/zenoh.dev.aichallenge-board.jsae.or.jp:${PORT}" -c /vehicle/zenoh.json5
+    status=$?
+    echo "zenoh-bridge-ros2dds exited with status ${status}; retrying in 5s..."
+    sleep 5
+done


### PR DESCRIPTION
## Description
racingkart_interfaceとzenohのコンテナのログを、autowareと同様の仕組みで記録するようにする。

## Test
以下のコマンドでログが生成されることを確認。
```
masahirokubota@npc2307029:~/aichallenge-racingkart$ make autoware-driver-zenoh
LOG_DIR=/output/20260601-012140 RUN_MODE=vehicle docker compose up -d driver autoware
[+] Running 2/2
 ✔ Container aichallenge-racingkart-autoware-1  Started                                          2.0s 
 ✔ Container aichallenge-racingkart-driver-1    S...                                             1.7s 
sleep 15
LOG_DIR=/output/20260601-012140 docker compose up -d zenoh
[+] Running 1/1
 ✔ Container aichallenge-racingkart-zenoh-1  Start...                                            0.2s 
```
<img width="321" height="161" alt="image" src="https://github.com/user-attachments/assets/81aeafc7-fb63-4404-8712-5a685b74508b" />

