### PR TITLE
fix: start rosbag before zenoh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,13 +93,11 @@ autoware-driver-zenoh:
 	sleep 15
 	LOG_DIR=$(LOG_DIR) docker compose up -d zenoh
 
-# driver + autoware + zenoh + all-topic rosbag
+# driver + autoware + all-topic rosbag + zenoh
 autoware-driver-zenoh-rosbag:
-	LOG_DIR=$(LOG_DIR) RUN_MODE=vehicle docker compose up -d driver autoware
+	LOG_DIR=$(LOG_DIR) RUN_MODE=vehicle docker compose up -d driver autoware rosbag
 	sleep 15
 	LOG_DIR=$(LOG_DIR) docker compose up -d zenoh
-	sleep 5
-	LOG_DIR=$(LOG_DIR) docker compose up -d rosbag
 
 down:
 	@for p in 1 2 3 4; do docker compose -p $$p down --remove-orphans; done


### PR DESCRIPTION
## Summary
すべてのノードが立ち上がった後にzenohを起動するために、rosbagノードをautowaraやdriverと同じタイミングで立ち上げる。

## Verification
zenohだけが15秒のsleepの後に起動されることを確認。
```
tier4@ECU-RK-03:~/aichallenge-racingkart$ make autoware-driver-zenoh-rosbag 
LOG_DIR=/output/20260602-193540 RUN_MODE=vehicle docker compose up -d driver autoware rosbag
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
[+] Running 3/3
 ✔ Container aichallenge-racingkart-rosbag-1    Started                                                                                                  0.3s 
 ✔ Container aichallenge-racingkart-driver-1    Started                                                                                                  0.3s 
 ✔ Container aichallenge-racingkart-autoware-1  Started                                                                                                  0.3s 
sleep 15
LOG_DIR=/output/20260602-193540 docker compose up -d zenoh
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DISPLAY" variable is not set. Defaulting to a blank string. 
[+] Running 1/1
 ✔ Container aichallenge-racingkart-zenoh-1  Started     
```