### PR TITLE
feat(system): add standalone Qt screen recorder package

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14)
+project(aichallenge_screen_recorder)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+find_package(OpenCV REQUIRED)
+find_package(Qt5 REQUIRED Core Gui Widgets)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+include_directories(
+  ${OpenCV_INCLUDE_DIRS}
+)
+
+ament_auto_add_executable(screen_recorder_node
+  src/screen_recorder_node.hpp
+  src/screen_recorder_node.cpp
+)
+target_link_libraries(screen_recorder_node
+  ${QT_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+    launch
+)

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/CMakeLists.txt
@@ -4,8 +4,8 @@ project(aichallenge_screen_recorder)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 find_package(OpenCV REQUIRED)
-find_package(Qt5 REQUIRED Core Gui Widgets)
-set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Widgets)
+find_package(Qt5 REQUIRED Core Gui)
+set(QT_LIBRARIES Qt5::Core Qt5::Gui)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -16,11 +16,22 @@ include_directories(
 ament_auto_add_executable(screen_recorder_node
   src/screen_recorder_node.hpp
   src/screen_recorder_node.cpp
+  src/encoder_worker.cpp
 )
 target_link_libraries(screen_recorder_node
   ${QT_LIBRARIES}
   ${OpenCV_LIBRARIES}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_encoder_worker
+    test/test_encoder_worker.cpp
+    src/encoder_worker.cpp
+  )
+  target_include_directories(test_encoder_worker PRIVATE src)
+  target_link_libraries(test_encoder_worker ${OpenCV_LIBRARIES})
+endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/launch/screen_recorder.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/launch/screen_recorder.launch.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+    <arg name="service_name" default="/debug/service/capture_screen"/>
+    <arg name="output_dir" default="capture"/>
+    <arg name="filename_prefix" default="cap"/>
+    <arg name="hz" default="10"/>
+
+    <node pkg="aichallenge_screen_recorder" exec="screen_recorder_node" name="screen_recorder" output="screen">
+        <param name="service_name" value="$(var service_name)"/>
+        <param name="output_dir" value="$(var output_dir)"/>
+        <param name="filename_prefix" value="$(var filename_prefix)"/>
+        <env name="AIC_SCREEN_RECORDER_HZ" value="$(var hz)"/>
+    </node>
+</launch>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/launch/screen_recorder.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/launch/screen_recorder.launch.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
     <arg name="service_name" default="/debug/service/capture_screen"/>
+    <!-- output_dir should be an absolute path; a relative path resolves against the node's working directory. -->
     <arg name="output_dir" default="capture"/>
     <arg name="filename_prefix" default="cap"/>
+    <!-- hz is passed via env because the recorder is created before the ROS node exists (see main()). -->
     <arg name="hz" default="10"/>
 
     <node pkg="aichallenge_screen_recorder" exec="screen_recorder_node" name="screen_recorder" output="screen">

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/package.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/package.xml
@@ -12,13 +12,11 @@
   <build_depend>autoware_cmake</build_depend>
 
   <depend>libopencv-dev</depend>
-  <depend>libqt5-core</depend>
-  <depend>libqt5-gui</depend>
-  <depend>libqt5-widgets</depend>
   <depend>qtbase5-dev</depend>
   <depend>rclcpp</depend>
   <depend>std_srvs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/package.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>aichallenge_screen_recorder</name>
+  <version>0.1.0</version>
+  <description>Standalone Qt + OpenCV full-screen recorder for AI Challenge. Replaces the rviz AutowareScreenCapturePanel so screen capture works without launching rviz.</description>
+  <maintainer email="taiki.tanaka@tier4.jp">Taiki, Tanaka</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <build_depend>autoware_cmake</build_depend>
+
+  <depend>libopencv-dev</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-gui</depend>
+  <depend>libqt5-widgets</depend>
+  <depend>qtbase5-dev</depend>
+  <depend>rclcpp</depend>
+  <depend>std_srvs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/encoder_worker.cpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/encoder_worker.cpp
@@ -1,0 +1,93 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "encoder_worker.hpp"
+
+#include <cstdio>
+#include <memory>
+#include <utility>
+
+EncoderWorker::EncoderWorker(
+  std::unique_ptr<cv::VideoWriter> writer, cv::Size size, std::size_t max_queue)
+: writer_(std::move(writer)), size_(size), max_queue_(max_queue)
+{
+  thread_ = std::thread(&EncoderWorker::run, this);
+}
+
+EncoderWorker::~EncoderWorker()
+{
+  if (!stop_.load()) {
+    stop();
+  }
+}
+
+void EncoderWorker::submit(cv::Mat frame)
+{
+  {
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (queue_.size() >= max_queue_) {
+      ++dropped_;
+      if (dropped_ == 1 || dropped_ % 100 == 0) {
+        std::fprintf(
+          stderr, "[screen_recorder] encoder queue full, dropped %zu frames so far\n", dropped_);
+      }
+      return;
+    }
+    queue_.push_back(std::move(frame));
+  }
+  cv_.notify_one();
+}
+
+std::size_t EncoderWorker::stop()
+{
+  stop_.store(true);
+  cv_.notify_all();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+  if (writer_) {
+    writer_->release();
+    writer_.reset();
+  }
+  return dropped_;
+}
+
+void EncoderWorker::run()
+{
+  while (true) {
+    cv::Mat frame;
+    {
+      std::unique_lock<std::mutex> lk(mtx_);
+      cv_.wait(lk, [this] { return stop_.load() || !queue_.empty(); });
+      if (queue_.empty()) {
+        if (stop_.load()) {
+          break;
+        }
+        continue;
+      }
+      frame = std::move(queue_.front());
+      queue_.pop_front();
+    }
+    if (frame.empty() || !writer_) {
+      continue;
+    }
+    if (frame.cols != size_.width || frame.rows != size_.height) {
+      cv::Mat resized;
+      cv::resize(frame, resized, size_);
+      writer_->write(resized);
+    } else {
+      writer_->write(frame);
+    }
+  }
+}

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/encoder_worker.hpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/encoder_worker.hpp
@@ -1,0 +1,51 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ENCODER_WORKER_HPP_
+#define ENCODER_WORKER_HPP_
+
+#include <opencv2/opencv.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+class EncoderWorker
+{
+public:
+  EncoderWorker(std::unique_ptr<cv::VideoWriter> writer, cv::Size size, std::size_t max_queue);
+  ~EncoderWorker();
+
+  void submit(cv::Mat frame);
+  std::size_t stop();  // returns dropped frame count
+
+private:
+  void run();
+
+  std::unique_ptr<cv::VideoWriter> writer_;
+  cv::Size size_;
+  std::size_t max_queue_;
+  std::deque<cv::Mat> queue_;
+  std::mutex mtx_;
+  std::condition_variable cv_;
+  std::atomic<bool> stop_{false};
+  std::size_t dropped_{0};
+  std::thread thread_;
+};
+
+#endif  // ENCODER_WORKER_HPP_

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.cpp
@@ -1,0 +1,290 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "screen_recorder_node.hpp"
+
+#include <QApplication>
+#include <QDir>
+#include <QGuiApplication>
+#include <QImage>
+#include <QPixmap>
+#include <QScreen>
+
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <utility>
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+namespace
+{
+std::string nowStamp()
+{
+  auto t = std::time(nullptr);
+  std::tm tm{};
+  localtime_r(&t, &tm);
+  std::ostringstream os;
+  os << std::put_time(&tm, "%Y%m%d-%H%M%S");
+  return os.str();
+}
+}  // namespace
+
+EncoderWorker::EncoderWorker(
+  std::unique_ptr<cv::VideoWriter> writer, cv::Size size, std::size_t max_queue)
+: writer_(std::move(writer)), size_(size), max_queue_(max_queue)
+{
+  thread_ = std::thread(&EncoderWorker::run, this);
+}
+
+EncoderWorker::~EncoderWorker()
+{
+  if (!stop_.load()) {
+    stop();
+  }
+}
+
+void EncoderWorker::submit(cv::Mat frame)
+{
+  {
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (queue_.size() >= max_queue_) {
+      ++dropped_;
+      return;
+    }
+    queue_.push_back(std::move(frame));
+  }
+  cv_.notify_one();
+}
+
+std::size_t EncoderWorker::stop()
+{
+  stop_.store(true);
+  cv_.notify_all();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+  if (writer_) {
+    writer_->release();
+    writer_.reset();
+  }
+  return dropped_;
+}
+
+void EncoderWorker::run()
+{
+  while (true) {
+    cv::Mat frame;
+    {
+      std::unique_lock<std::mutex> lk(mtx_);
+      cv_.wait(lk, [this] { return stop_.load() || !queue_.empty(); });
+      if (queue_.empty()) {
+        if (stop_.load()) {
+          break;
+        }
+        continue;
+      }
+      frame = std::move(queue_.front());
+      queue_.pop_front();
+    }
+    if (frame.empty() || !writer_) {
+      continue;
+    }
+    if (frame.cols != size_.width || frame.rows != size_.height) {
+      cv::Mat resized;
+      cv::resize(frame, resized, size_);
+      writer_->write(resized);
+    } else {
+      writer_->write(frame);
+    }
+  }
+}
+
+ScreenRecorder::ScreenRecorder(int hz, QObject * parent) : QObject(parent), hz_(std::max(1, hz))
+{
+  timer_.setTimerType(Qt::PreciseTimer);
+  timer_.setInterval(static_cast<int>(1000.0 / hz_));
+  connect(&timer_, &QTimer::timeout, this, &ScreenRecorder::onTick);
+}
+
+cv::Mat ScreenRecorder::grabFrame()
+{
+  QScreen * screen = QGuiApplication::primaryScreen();
+  if (!screen) {
+    return {};
+  }
+  QPixmap pixmap = screen->grabWindow(0);
+  if (pixmap.isNull()) {
+    return {};
+  }
+  const QImage image = pixmap.toImage().convertToFormat(QImage::Format_RGB888).rgbSwapped();
+  const int w = image.width();
+  const int h = image.height();
+  cv::Mat tmp(
+    h, w, CV_8UC3, const_cast<uchar *>(image.bits()), static_cast<size_t>(image.bytesPerLine()));
+  return tmp.clone();
+}
+
+void ScreenRecorder::start(QString path)
+{
+  if (active_) {
+    emit statusChanged(true, QStringLiteral("already recording"));
+    return;
+  }
+
+  const std::string path_str = path.toStdString();
+  std::filesystem::create_directories(std::filesystem::path(path_str).parent_path());
+
+  cv::Mat sample = grabFrame();
+  if (sample.empty()) {
+    emit statusChanged(false, QStringLiteral("no primary screen"));
+    return;
+  }
+  size_ = cv::Size(sample.cols, sample.rows);
+
+  std::unique_ptr<cv::VideoWriter> writer;
+  for (const char * tag : {"avc1", "mp4v"}) {
+    auto candidate = std::make_unique<cv::VideoWriter>(
+      path_str, cv::VideoWriter::fourcc(tag[0], tag[1], tag[2], tag[3]), hz_, size_);
+    if (candidate->isOpened()) {
+      writer = std::move(candidate);
+      break;
+    }
+  }
+  if (!writer) {
+    emit statusChanged(false, QStringLiteral("failed to open writer: %1").arg(path));
+    return;
+  }
+
+  encoder_ = std::make_unique<EncoderWorker>(std::move(writer), size_, /*max_queue=*/30);
+  encoder_->submit(std::move(sample));
+  active_ = true;
+  timer_.start();
+  emit statusChanged(
+    true, QStringLiteral("recording %1x%2 @ %3Hz -> %4")
+            .arg(size_.width)
+            .arg(size_.height)
+            .arg(hz_)
+            .arg(path));
+}
+
+void ScreenRecorder::stop()
+{
+  if (!active_) {
+    emit statusChanged(false, QStringLiteral("not recording"));
+    return;
+  }
+  timer_.stop();
+  std::size_t dropped = 0;
+  if (encoder_) {
+    dropped = encoder_->stop();
+    encoder_.reset();
+  }
+  active_ = false;
+  emit statusChanged(false, QStringLiteral("stopped (dropped frames=%1)").arg(dropped));
+}
+
+void ScreenRecorder::onTick()
+{
+  if (!active_ || !encoder_) {
+    return;
+  }
+  cv::Mat frame = grabFrame();
+  if (!frame.empty()) {
+    encoder_->submit(std::move(frame));
+  }
+}
+
+ScreenRecorderNode::ScreenRecorderNode(ScreenRecorder * recorder, rclcpp::NodeOptions options)
+: rclcpp::Node("screen_recorder", options), recorder_(recorder)
+{
+  output_dir_ = this->declare_parameter<std::string>("output_dir", "capture");
+  prefix_ = this->declare_parameter<std::string>("filename_prefix", "cap");
+  const std::string service_name =
+    this->declare_parameter<std::string>("service_name", "/debug/service/capture_screen");
+
+  service_ = this->create_service<std_srvs::srv::Trigger>(
+    service_name, std::bind(&ScreenRecorderNode::onTrigger, this, _1, _2));
+
+  RCLCPP_INFO(
+    this->get_logger(), "screen_recorder ready: service=%s out_dir=%s prefix=%s",
+    service_name.c_str(), output_dir_.c_str(), prefix_.c_str());
+}
+
+void ScreenRecorderNode::onTrigger(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> /*req*/,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+{
+  if (!active_) {
+    const std::string path = output_dir_ + "/" + prefix_ + "-" + nowStamp() + ".mp4";
+    QMetaObject::invokeMethod(
+      recorder_, "start", Qt::QueuedConnection, Q_ARG(QString, QString::fromStdString(path)));
+    active_ = true;
+    res->success = true;
+    res->message = "start: " + path;
+  } else {
+    QMetaObject::invokeMethod(recorder_, "stop", Qt::QueuedConnection);
+    active_ = false;
+    res->success = true;
+    res->message = "stop";
+  }
+  RCLCPP_INFO(this->get_logger(), "%s", res->message.c_str());
+}
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  QApplication app(argc, argv);
+
+  int hz = 10;
+  if (const char * env = std::getenv("AIC_SCREEN_RECORDER_HZ")) {
+    try {
+      hz = std::max(1, std::stoi(env));
+    } catch (...) {
+      hz = 10;
+    }
+  }
+
+  ScreenRecorder recorder(hz);
+  QObject::connect(
+    &recorder, &ScreenRecorder::statusChanged, [](bool active, const QString & msg) {
+      std::fprintf(
+        stderr, "[screen_recorder] active=%d %s\n", static_cast<int>(active), msg.toStdString().c_str());
+      std::fflush(stderr);
+    });
+
+  auto node = std::make_shared<ScreenRecorderNode>(&recorder, rclcpp::NodeOptions{});
+
+  // SIGINT path: rclcpp installs its own signal handler that calls rclcpp::shutdown().
+  // Forward shutdown to Qt so app.exec() returns and the encoder gets a chance to finalize the mp4.
+  rclcpp::on_shutdown([]() { QMetaObject::invokeMethod(qApp, "quit", Qt::QueuedConnection); });
+
+  std::thread spin_thread([node]() {
+    rclcpp::spin(node);
+  });
+
+  const int rc = app.exec();
+
+  // Back on the Qt main thread; call stop() directly to release the VideoWriter (writes mp4 moov atom).
+  recorder.stop();
+  rclcpp::shutdown();
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+  return rc;
+}

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.cpp
@@ -14,8 +14,6 @@
 
 #include "screen_recorder_node.hpp"
 
-#include <QApplication>
-#include <QDir>
 #include <QGuiApplication>
 #include <QImage>
 #include <QPixmap>
@@ -24,6 +22,7 @@
 #include <chrono>
 #include <ctime>
 #include <filesystem>
+#include <future>
 #include <iomanip>
 #include <memory>
 #include <sstream>
@@ -45,76 +44,6 @@ std::string nowStamp()
 }
 }  // namespace
 
-EncoderWorker::EncoderWorker(
-  std::unique_ptr<cv::VideoWriter> writer, cv::Size size, std::size_t max_queue)
-: writer_(std::move(writer)), size_(size), max_queue_(max_queue)
-{
-  thread_ = std::thread(&EncoderWorker::run, this);
-}
-
-EncoderWorker::~EncoderWorker()
-{
-  if (!stop_.load()) {
-    stop();
-  }
-}
-
-void EncoderWorker::submit(cv::Mat frame)
-{
-  {
-    std::lock_guard<std::mutex> lk(mtx_);
-    if (queue_.size() >= max_queue_) {
-      ++dropped_;
-      return;
-    }
-    queue_.push_back(std::move(frame));
-  }
-  cv_.notify_one();
-}
-
-std::size_t EncoderWorker::stop()
-{
-  stop_.store(true);
-  cv_.notify_all();
-  if (thread_.joinable()) {
-    thread_.join();
-  }
-  if (writer_) {
-    writer_->release();
-    writer_.reset();
-  }
-  return dropped_;
-}
-
-void EncoderWorker::run()
-{
-  while (true) {
-    cv::Mat frame;
-    {
-      std::unique_lock<std::mutex> lk(mtx_);
-      cv_.wait(lk, [this] { return stop_.load() || !queue_.empty(); });
-      if (queue_.empty()) {
-        if (stop_.load()) {
-          break;
-        }
-        continue;
-      }
-      frame = std::move(queue_.front());
-      queue_.pop_front();
-    }
-    if (frame.empty() || !writer_) {
-      continue;
-    }
-    if (frame.cols != size_.width || frame.rows != size_.height) {
-      cv::Mat resized;
-      cv::resize(frame, resized, size_);
-      writer_->write(resized);
-    } else {
-      writer_->write(frame);
-    }
-  }
-}
-
 ScreenRecorder::ScreenRecorder(int hz, QObject * parent) : QObject(parent), hz_(std::max(1, hz))
 {
   timer_.setTimerType(Qt::PreciseTimer);
@@ -128,6 +57,7 @@ cv::Mat ScreenRecorder::grabFrame()
   if (!screen) {
     return {};
   }
+  // X11 only: on Wayland grabWindow() returns a null/empty pixmap.
   QPixmap pixmap = screen->grabWindow(0);
   if (pixmap.isNull()) {
     return {};
@@ -140,11 +70,11 @@ cv::Mat ScreenRecorder::grabFrame()
   return tmp.clone();
 }
 
-void ScreenRecorder::start(QString path)
+bool ScreenRecorder::start(const QString & path)
 {
   if (active_) {
     emit statusChanged(true, QStringLiteral("already recording"));
-    return;
+    return true;
   }
 
   const std::string path_str = path.toStdString();
@@ -153,10 +83,13 @@ void ScreenRecorder::start(QString path)
   cv::Mat sample = grabFrame();
   if (sample.empty()) {
     emit statusChanged(false, QStringLiteral("no primary screen"));
-    return;
+    return false;
   }
   size_ = cv::Size(sample.cols, sample.rows);
 
+  // Known limitations: the writer fps is the nominal capture rate, so dropped frames or timer
+  // jitter make playback run faster than wall clock. The mp4 index (moov atom) is only written
+  // on release(), so a SIGKILL before stop() leaves an unplayable file.
   std::unique_ptr<cv::VideoWriter> writer;
   for (const char * tag : {"avc1", "mp4v"}) {
     auto candidate = std::make_unique<cv::VideoWriter>(
@@ -168,7 +101,7 @@ void ScreenRecorder::start(QString path)
   }
   if (!writer) {
     emit statusChanged(false, QStringLiteral("failed to open writer: %1").arg(path));
-    return;
+    return false;
   }
 
   encoder_ = std::make_unique<EncoderWorker>(std::move(writer), size_, /*max_queue=*/30);
@@ -181,6 +114,7 @@ void ScreenRecorder::start(QString path)
             .arg(size_.height)
             .arg(hz_)
             .arg(path));
+  return true;
 }
 
 void ScreenRecorder::stop()
@@ -214,6 +148,8 @@ ScreenRecorderNode::ScreenRecorderNode(ScreenRecorder * recorder, rclcpp::NodeOp
 : rclcpp::Node("screen_recorder", options), recorder_(recorder)
 {
   output_dir_ = this->declare_parameter<std::string>("output_dir", "capture");
+  // Resolve relative paths against the CWD once so the log below shows where files actually go.
+  output_dir_ = std::filesystem::absolute(output_dir_).string();
   prefix_ = this->declare_parameter<std::string>("filename_prefix", "cap");
   const std::string service_name =
     this->declare_parameter<std::string>("service_name", "/debug/service/capture_screen");
@@ -230,27 +166,40 @@ void ScreenRecorderNode::onTrigger(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> /*req*/,
   std::shared_ptr<std_srvs::srv::Trigger::Response> res)
 {
-  if (!active_) {
+  // Run start()/stop() on the Qt thread and wait for the result, so the response reflects the
+  // actual recorder state and the mp4 is fully finalized before the stop response is sent.
+  if (!recorder_->active()) {
     const std::string path = output_dir_ + "/" + prefix_ + "-" + nowStamp() + ".mp4";
-    QMetaObject::invokeMethod(
-      recorder_, "start", Qt::QueuedConnection, Q_ARG(QString, QString::fromStdString(path)));
-    active_ = true;
-    res->success = true;
-    res->message = "start: " + path;
+    const QString qpath = QString::fromStdString(path);
+    res->success = callOnQtThread([this, qpath] { return recorder_->start(qpath); });
+    res->message = (res->success ? "start: " : "failed to start: ") + path;
   } else {
-    QMetaObject::invokeMethod(recorder_, "stop", Qt::QueuedConnection);
-    active_ = false;
-    res->success = true;
-    res->message = "stop";
+    res->success = callOnQtThread([this] {
+      recorder_->stop();
+      return true;
+    });
+    res->message = res->success ? "stop" : "failed to stop (Qt event loop unavailable)";
   }
   RCLCPP_INFO(this->get_logger(), "%s", res->message.c_str());
+}
+
+bool ScreenRecorderNode::callOnQtThread(std::function<bool()> fn)
+{
+  auto promise = std::make_shared<std::promise<bool>>();
+  auto future = promise->get_future();
+  QMetaObject::invokeMethod(
+    recorder_, [promise, fn = std::move(fn)] { promise->set_value(fn()); }, Qt::QueuedConnection);
+  // Timeout guards against a stopped Qt event loop (e.g. during shutdown).
+  return future.wait_for(std::chrono::seconds(5)) == std::future_status::ready && future.get();
 }
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  QApplication app(argc, argv);
+  QGuiApplication app(argc, argv);
 
+  // hz comes from an env var rather than a ROS parameter because the recorder must be
+  // constructed on the Qt main thread before the ROS node (which owns the parameters) exists.
   int hz = 10;
   if (const char * env = std::getenv("AIC_SCREEN_RECORDER_HZ")) {
     try {

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.hpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.hpp
@@ -15,6 +15,8 @@
 #ifndef SCREEN_RECORDER_NODE_HPP_
 #define SCREEN_RECORDER_NODE_HPP_
 
+#include "encoder_worker.hpp"
+
 #include <QObject>
 #include <QString>
 #include <QTimer>
@@ -25,35 +27,9 @@
 #include <std_srvs/srv/trigger.hpp>
 
 #include <atomic>
-#include <condition_variable>
-#include <deque>
+#include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <thread>
-
-class EncoderWorker
-{
-public:
-  EncoderWorker(std::unique_ptr<cv::VideoWriter> writer, cv::Size size, std::size_t max_queue);
-  ~EncoderWorker();
-
-  void submit(cv::Mat frame);
-  std::size_t stop();  // returns dropped frame count
-
-private:
-  void run();
-
-  std::unique_ptr<cv::VideoWriter> writer_;
-  cv::Size size_;
-  std::size_t max_queue_;
-  std::deque<cv::Mat> queue_;
-  std::mutex mtx_;
-  std::condition_variable cv_;
-  std::atomic<bool> stop_{false};
-  std::size_t dropped_{0};
-  std::thread thread_;
-};
 
 class ScreenRecorder : public QObject
 {
@@ -63,13 +39,14 @@ public:
   explicit ScreenRecorder(int hz, QObject * parent = nullptr);
   ~ScreenRecorder() override = default;
 
-  bool active() const { return active_; }
+  // Thread-safe: the single source of truth for the recording state.
+  bool active() const { return active_.load(); }
 
 signals:
   void statusChanged(bool active, QString message);
 
 public slots:
-  void start(QString path);
+  bool start(const QString & path);  // returns whether recording is active afterwards
   void stop();
 
 private slots:
@@ -80,7 +57,7 @@ private:
 
   int hz_;
   cv::Size size_{};
-  bool active_{false};
+  std::atomic<bool> active_{false};
   std::unique_ptr<EncoderWorker> encoder_;
   QTimer timer_;
 };
@@ -94,11 +71,11 @@ private:
   void onTrigger(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
     std::shared_ptr<std_srvs::srv::Trigger::Response> res);
+  bool callOnQtThread(std::function<bool()> fn);
 
   ScreenRecorder * recorder_;
   std::string output_dir_;
   std::string prefix_;
-  bool active_{false};
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr service_;
 };
 

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.hpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/src/screen_recorder_node.hpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SCREEN_RECORDER_NODE_HPP_
+#define SCREEN_RECORDER_NODE_HPP_
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+#include <opencv2/opencv.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <std_srvs/srv/trigger.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+class EncoderWorker
+{
+public:
+  EncoderWorker(std::unique_ptr<cv::VideoWriter> writer, cv::Size size, std::size_t max_queue);
+  ~EncoderWorker();
+
+  void submit(cv::Mat frame);
+  std::size_t stop();  // returns dropped frame count
+
+private:
+  void run();
+
+  std::unique_ptr<cv::VideoWriter> writer_;
+  cv::Size size_;
+  std::size_t max_queue_;
+  std::deque<cv::Mat> queue_;
+  std::mutex mtx_;
+  std::condition_variable cv_;
+  std::atomic<bool> stop_{false};
+  std::size_t dropped_{0};
+  std::thread thread_;
+};
+
+class ScreenRecorder : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit ScreenRecorder(int hz, QObject * parent = nullptr);
+  ~ScreenRecorder() override = default;
+
+  bool active() const { return active_; }
+
+signals:
+  void statusChanged(bool active, QString message);
+
+public slots:
+  void start(QString path);
+  void stop();
+
+private slots:
+  void onTick();
+
+private:
+  cv::Mat grabFrame();
+
+  int hz_;
+  cv::Size size_{};
+  bool active_{false};
+  std::unique_ptr<EncoderWorker> encoder_;
+  QTimer timer_;
+};
+
+class ScreenRecorderNode : public rclcpp::Node
+{
+public:
+  ScreenRecorderNode(ScreenRecorder * recorder, rclcpp::NodeOptions options);
+
+private:
+  void onTrigger(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> res);
+
+  ScreenRecorder * recorder_;
+  std::string output_dir_;
+  std::string prefix_;
+  bool active_{false};
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr service_;
+};
+
+#endif  // SCREEN_RECORDER_NODE_HPP_

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/test/test_encoder_worker.cpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_screen_recorder/test/test_encoder_worker.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "encoder_worker.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <future>
+#include <memory>
+#include <utility>
+
+namespace
+{
+// VideoWriter mock: blocks inside the first write() until the gate opens, so the test can fill
+// the queue deterministically while the worker is busy.
+class GateWriter : public cv::VideoWriter
+{
+public:
+  GateWriter(std::atomic<int> & written, std::promise<void> & first_write, std::shared_future<void> gate)
+  : written_(written), first_write_(first_write), gate_(std::move(gate))
+  {
+  }
+
+  bool isOpened() const override { return true; }
+  void release() override {}
+  void write(cv::InputArray /*image*/) override
+  {
+    if (!started_) {
+      started_ = true;
+      first_write_.set_value();
+      gate_.wait();
+    }
+    ++written_;
+  }
+
+private:
+  std::atomic<int> & written_;
+  std::promise<void> & first_write_;
+  std::shared_future<void> gate_;
+  bool started_{false};
+};
+}  // namespace
+
+TEST(EncoderWorker, DropsFramesWhenQueueIsFullAndDrainsOnStop)
+{
+  std::atomic<int> written{0};
+  std::promise<void> first_write;
+  auto first_write_started = first_write.get_future();
+  std::promise<void> gate;
+  auto writer = std::make_unique<GateWriter>(written, first_write, gate.get_future().share());
+
+  const cv::Size size(4, 4);
+  constexpr std::size_t kMaxQueue = 3;
+  EncoderWorker worker(std::move(writer), size, kMaxQueue);
+
+  const cv::Mat frame(size, CV_8UC3, cv::Scalar(0, 0, 0));
+
+  // The worker pops this frame and blocks inside write() until the gate opens.
+  worker.submit(frame.clone());
+  first_write_started.wait();
+
+  // Queue is empty and the worker is blocked: fill the queue, then overflow it.
+  for (std::size_t i = 0; i < kMaxQueue; ++i) {
+    worker.submit(frame.clone());
+  }
+  worker.submit(frame.clone());  // dropped
+  worker.submit(frame.clone());  // dropped
+
+  gate.set_value();
+  const std::size_t dropped = worker.stop();
+
+  EXPECT_EQ(dropped, 2u);
+  EXPECT_EQ(written.load(), static_cast<int>(1 + kMaxQueue));
+}

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/package.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>aichallenge_screen_recorder</exec_depend>
   <exec_depend>aichallenge_submit_launch</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbag2_py</exec_depend>


### PR DESCRIPTION
## 概要

  rviz の `AutowareScreenCapturePanel` に依存せず画面録画できる独立パッケージ
  `aichallenge_screen_recorder` を追加します。rviz を起動しないヘッドレス評価でも
  `autostart_orchestrator` からの画面キャプチャを可能にすることが目的です。

  ## 仕組み

  - `std_srvs/srv/Trigger` サービス（既定: `/debug/service/capture_screen`）を
    トグルとして公開（1回目=録画開始 / 2回目=停止）
  - Qt メインスレッドで `QScreen::grabWindow()` により画面取得（`QTimer`, 既定 10Hz）
  - エンコードは専用ワーカースレッドに分離（`EncoderWorker`、キュー上限 30 フレーム、
    満杯時はドロップして throttle 付き警告 + 停止時に集計報告）
  - `cv::VideoWriter` で mp4 出力（fourcc は `avc1` → `mp4v` フォールバック）
  - ファイル名は `<output_dir>/<prefix>-YYYYMMDD-HHMMSS.mp4`。`output_dir` は起動時に
    絶対パス化され、orchestrator の `cap-*.mp4` 回収パターンと整合

  ### 設計上のポイント

  - **サービス応答は実際の録画状態を反映**: `start()`/`stop()` を Qt スレッドへ
    promise/future（5s タイムアウト）で同期実行。画面が取得できない・writer が
    開けない場合は `success=false` を返す
  - **stop 応答時点で mp4 finalize 完了が保証**: moov atom 書き込み後に応答するため、
    呼び出し側（orchestrator）が直後にファイルをコピーしても壊れない
  - **graceful shutdown**: `rclcpp::on_shutdown` → Qt event loop 終了 → encoder drain →
    `VideoWriter::release()` の順で SIGINT 時も再生可能な mp4 を残す
  - `hz` のみ環境変数 `AIC_SCREEN_RECORDER_HZ`（recorder を ROS node より先に
    Qt メインスレッドで生成する必要があるため。コード内コメント参照)

  ## 制約事項

  - X11 のみ対応（Wayland では `grabWindow()` が空画像を返す）
  - SIGKILL 等で finalize 前に落ちた場合 mp4 は再生不能
  - writer の fps は公称キャプチャレート固定のため、フレームドロップ時は
    再生速度が実時間より速くなる
  
  ## スコープ外（別PR）

  - launch 統合（`mode/awsim.launch.xml` への include と `output_dir` の配線）。
    本PRはパッケージ追加と `aichallenge_system_launch` への `exec_depend` 追加まで

  ## 使い方

  ```bash
  ros2 launch aichallenge_screen_recorder screen_recorder.launch.xml \
    output_dir:=/output/capture hz:=10
  ros2 service call /debug/service/capture_screen std_srvs/srv/Trigger  # 開始
  ros2 service call /debug/service/capture_screen std_srvs/srv/Trigger  # 停止

  テスト

  - [x] make autoware-build
  - [x] colcon test: 19 tests, 0 errors, 0 failures（lint 含む）<-これどうしようかな
  - [x] pre-commit（check xml / end-of-files 等）合格