### PR TITLE
fix(orchestrator): add timeout to initial pose service call

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -94,6 +94,8 @@ class AutostartOrchestrator(Node):
         self.declare_parameter("enable_motion_analytics", True)
         self.declare_parameter("motion_analytics_cmd", "ros2 run aichallenge_system_launch motion_analytics.py")
         self.declare_parameter("motion_analytics_input_dir", "")
+        # 0 or negative => wait forever (legacy behavior).
+        self.declare_parameter("initial_pose_service_timeout_sec", 120.0)
 
         vehicle_state_topic = str(self.get_parameter("vehicle_state_topic").value).strip()
         if not vehicle_state_topic:
@@ -466,15 +468,25 @@ class AutostartOrchestrator(Node):
             return
 
         if call_initial_pose:
+            timeout_sec = float(self.get_parameter("initial_pose_service_timeout_sec").value)
+            timeout_arg: Optional[float] = timeout_sec if timeout_sec > 0.0 else None
             self._set_workflow_state(
                 self._STATE_WAIT_INITIAL_POSE,
-                f"waiting service and calling {self.get_parameter('initial_pose_service').value}",
+                f"waiting service and calling {self.get_parameter('initial_pose_service').value}"
+                + (f" (timeout {timeout_sec:.0f}s)" if timeout_arg is not None else ""),
             )
-            if self._wait_for_service(self._cli_initial_pose):
-                ok, msg = self._call_trigger(self._cli_initial_pose)
-                self.get_logger().info(f"initial pose: success={ok} msg={msg}")
+            if self._wait_for_service(self._cli_initial_pose, timeout_sec=timeout_arg):
+                ok, msg = self._call_trigger(self._cli_initial_pose, timeout_sec=timeout_arg)
+                if ok:
+                    self.get_logger().info(f"initial pose: success={ok} msg={msg}")
+                else:
+                    self.get_logger().warn(
+                        f"skip initial pose (call failed/timed out): {msg}; proceeding to capture/rosbag"
+                    )
             else:
-                self.get_logger().warn("skip initial pose (service not found)")
+                self.get_logger().warn(
+                    "skip initial pose (service not found within timeout); proceeding to capture/rosbag"
+                )
 
         self._set_workflow_state(self._STATE_REQUEST_CONTROL_MODE, "initial pose completed")
 
@@ -491,10 +503,12 @@ class AutostartOrchestrator(Node):
 
         self._set_workflow_state(self._STATE_REQUEST_CONTROL_MODE, "initialization done")
 
-    def _wait_for_service(self, client) -> bool:
-        return client.wait_for_service()
+    def _wait_for_service(self, client, timeout_sec: Optional[float] = None) -> bool:
+        if timeout_sec is None:
+            return client.wait_for_service()
+        return client.wait_for_service(timeout_sec=timeout_sec)
 
-    def _call_trigger(self, client) -> tuple[bool, str]:
+    def _call_trigger(self, client, timeout_sec: Optional[float] = None) -> tuple[bool, str]:
         event = threading.Event()
         result: tuple[bool, str] = (False, "no_response")
 
@@ -511,7 +525,14 @@ class AutostartOrchestrator(Node):
                 event.set()
 
         future.add_done_callback(_done)
-        event.wait()
+        if not event.wait(timeout=timeout_sec):
+            # Drop the unresolved future so we don't leak a pending request,
+            # and report timeout so callers can fall through to next step.
+            try:
+                client.remove_pending_request(future)
+            except Exception:  # noqa: BLE001
+                pass
+            return (False, f"timeout ({timeout_sec}s)")
         return result
 
     def _publish_control_mode(self) -> tuple[bool, str]:

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/autostart_orchestrator_py/autostart_orchestrator_node.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess
 import queue
 import threading
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -475,8 +476,12 @@ class AutostartOrchestrator(Node):
                 f"waiting service and calling {self.get_parameter('initial_pose_service').value}"
                 + (f" (timeout {timeout_sec:.0f}s)" if timeout_arg is not None else ""),
             )
+            # One deadline bounds the whole step: wait_for_service consumes part of it
+            # and the trigger call only gets the remainder.
+            deadline = None if timeout_arg is None else time.monotonic() + timeout_arg
             if self._wait_for_service(self._cli_initial_pose, timeout_sec=timeout_arg):
-                ok, msg = self._call_trigger(self._cli_initial_pose, timeout_sec=timeout_arg)
+                remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+                ok, msg = self._call_trigger(self._cli_initial_pose, timeout_sec=remaining)
                 if ok:
                     self.get_logger().info(f"initial pose: success={ok} msg={msg}")
                 else:

--- a/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/config/autostart_orchestrator.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_system/autostart_orchestrator_py/config/autostart_orchestrator.param.yaml
@@ -8,6 +8,10 @@
     call_initial_pose: true
     request_control_mode: true
     initial_pose_service: /set_initial_pose
+    # If the submission does not advertise /set_initial_pose, or it never
+    # responds, skip after this many seconds and proceed to capture/rosbag
+    # so the run is still recorded for diagnostics.
+    initial_pose_service_timeout_sec: 60
     control_mode_request_topic: /awsim/control_mode_request_topic
     capture_service: /debug/service/capture_screen
     enable_debug_visualization: true


### PR DESCRIPTION
The orchestrator waited forever for /set_initial_pose; a submission that does not advertise the service (or never responds) hung the evaluation until the external timeout, leaving no capture/rosbag for diagnostics.

Bound both wait_for_service and the trigger call with initial_pose_service_timeout_sec (60s in param.yaml, 0 or negative = wait forever) and proceed to capture/rosbag on timeout so the run is still recorded. The unresolved future is removed from the client to avoid leaking a pending request.

(cherry picked from commit 83426c56c9ffdfedb690ab8ef6768f262575795c)