### PR TITLE
chore(setup): exit bootstrap after docker group add and prompt re-login

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -416,7 +416,10 @@ ensure_docker_group() {
     log "${INFO} Adding ${USER-} to docker group"
     sudo_refresh
     sudo usermod -aG docker "${USER-}"
-    warn "${WARN} Docker group takes effect after re-login (or reboot)."
+    warn "${WARN} Docker group takes effect after re-login."
+    warn "${INFO} To apply: log out and log back in, or run 'newgrp docker' in this terminal."
+    warn "${INFO} Then re-run: ./setup.bash bootstrap"
+    exit 0
 }
 
 clone_or_update_repo() {

--- a/setup.bash
+++ b/setup.bash
@@ -417,8 +417,12 @@ ensure_docker_group() {
     sudo_refresh
     sudo usermod -aG docker "${USER-}"
     warn "${WARN} Docker group takes effect after re-login."
+    if [ "${SETUP_ASSUME_YES}" = "1" ]; then
+        warn "${INFO} Non-interactive mode: continuing, but docker commands may fail until re-login."
+        return 0
+    fi
     warn "${INFO} To apply: log out and log back in, or run 'newgrp docker' in this terminal."
-    warn "${INFO} Then re-run: ./setup.bash bootstrap"
+    warn "${INFO} Then re-run the same setup command to continue."
     exit 0
 }
 


### PR DESCRIPTION
- これまでDockerをインストールしたことがないPCでのセットアップ時に、ユーザーを混乱させてしまう挙動がありました。
- `setup.bash bootstrap` では、Docker をインストール後にユーザーを dockerグループに追加します。このとき、グループ変更が現在のセッションに即座に反映されないにもかかわらず、setup.bashの処理が進んでしまうという問題があります。
- その結果、どこに問題があったのか分かりづらくなります。（一応doctor等の出力メッセージを読めばわかりますが）
- 本PRでは、グループ追加後にスクリプトを正常終了させ、再ログインを促すよう修正しました。
  - `use_sudo` というフラグがこのケースを救うことを意図したものかもしれないですが、現状機能していないようです。また、仮にうまく言ったとしてもsudoでビルドが行われてしまうと、各ファイルがroot権限で作成されてしまうため、後で一般ユーザでアクセスすることができなくなってしまいます
  - そのため、潔く一度終了する方が余計なトラブルを招かないかと思います。

## 変更内容

`ensure_docker_group` において、`usermod -aG docker` 実行後に `exit 0` を呼び出すよう変更。

**変更前の動作:**
1. ユーザーを docker グループに追加
2. warn メッセージを1行出力してスクリプト継続
3. 以降の docker コマンドがグループ未反映のまま失敗

**変更後の動作:**
1. ユーザーを docker グループに追加
2. 再ログインを促すメッセージを出力
3. スクリプトを正常終了（`exit 0`）
4. ユーザーが再ログイン後に `./setup.bash bootstrap` を再実行して残りのステップを完了

## 補足

- 新しいターミナルを開くだけでは不十分（現在のデスクトップセッションのグループリストを引き継ぐため）
- 再ログインの代替手段として `newgrp docker` も案内している

## テスト

Docker 未インストールの環境から `./setup.bash bootstrap` を実行し、docker グループ追加後にスクリプトが正常終了することを確認済み。

<img width="924" height="179" alt="image" src="https://github.com/user-attachments/assets/8837d65d-2876-416c-aaac-d754a5b040f1" />
