### PR TITLE
feat(teleop_manager): support keyboard, geat command, boost command. Enable sudo in docker container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,11 @@ TEAM_NAME="ABC"
 ROS_DOMAIN_ID=1
 # Must be an absolute path because colcon --symlink-install can contain absolute symlinks.
 RACING_KART_INTERFACE_DIR=/home/tier4/racing_kart_interface
-# Host identity, auto-filled by `./setup.bash env` / `make` (id -u, id -g, dialout GID for /dev/vcu,/dev/gnss).
+# Host identity, auto-filled by `./setup.bash env` / `make` (id -u, id -g, dialout GID for /dev/vcu,/dev/gnss, input GID for /dev/input/event*).
 HOST_UID=1000
 HOST_GID=1000
 HOST_GID_DIALOUT=20
+HOST_GID_INPUT=104
 
 # Compose overlays (docker compose reads COMPOSE_FILE from .env). Pick "One" line:
 COMPOSE_FILE=docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,13 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 FROM common AS dev
 
+# Grant NOPASSWD sudo, and short-circuit PAM's account stack for sudo to work.
+# Note: The proper approach would be to create the user at container start in an entrypoint, but we keep this static rule for simplicity.
+RUN echo 'ALL ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/aichallenge-nopasswd \
+ && chmod 440 /etc/sudoers.d/aichallenge-nopasswd \
+ && visudo -cf /etc/sudoers.d/aichallenge-nopasswd \
+ && printf 'account sufficient pam_permit.so\n%s\n' "$(cat /etc/pam.d/sudo)" > /etc/pam.d/sudo
+
 RUN echo 'export PS1="\[\e]0;(AIC_DEV) ${debian_chroot:+($debian_chroot)}\u@\h: \w\a\](AIC_DEV) ${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/skel/.bashrc
 RUN echo 'cd /aichallenge' >> /etc/skel/.bashrc
 RUN echo 'eval $(resize)' >> /etc/skel/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 .PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control  awsim-request-start awsim-request-reset autoware-driver-zenoh autoware-driver-zenoh-rosbag \
-	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-bash eval
+	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-attach autoware-bash eval
 
 # Used by docker-compose.yml for build/eval artifact ownership.
 HOST_UID ?= $(shell id -u)
@@ -127,6 +127,9 @@ ps:
 			echo "$$out"; \
 		fi; \
 	done
+
+autoware-attach:
+	@./docker_exec.sh
 
 autoware-bash:
 	CMD="bash --rcfile /etc/skel/.bashrc -i" docker compose run --rm --no-deps autoware-command

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ps:
 	done
 
 autoware-bash:
-	@./docker_exec.sh $(VEHICLE_NUM)
+	CMD="bash --rcfile /etc/skel/.bashrc -i" docker compose run --rm --no-deps autoware-command
 
 # Download submission data by asking for credentials interactively
 # Usage:

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/control/joycon.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/control/joycon.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="input_source" default="joy" description="teleop input: joy | keyboard"/>
+  <arg name="input_source" default="joy" description="teleop input: joy | keyboard | keyboard_x11"/>
   <include file="$(find-pkg-share teleop_manager)/launch/teleop_manager.launch.xml">
     <arg name="input_source" value="$(var input_source)"/>
   </include>

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/control/joycon.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/control/joycon.launch.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <include file="$(find-pkg-share teleop_manager)/launch/teleop_manager.launch.xml"/>
+  <arg name="input_source" default="joy" description="teleop input: joy | keyboard"/>
+  <include file="$(find-pkg-share teleop_manager)/launch/teleop_manager.launch.xml">
+    <arg name="input_source" value="$(var input_source)"/>
+  </include>
 </launch>

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/CMakeLists.txt
@@ -14,6 +14,10 @@ ament_auto_add_executable(teleop_manager_node
   src/teleop_manager_node.cpp
 )
 
+ament_auto_add_executable(keyboard_to_joy_node
+  src/keyboard_to_joy_node.cpp
+)
+
 ament_auto_package(INSTALL_TO_SHARE
   config
   launch

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
+find_package(X11 REQUIRED)
 
 ament_auto_find_build_dependencies()
 
@@ -17,6 +18,12 @@ ament_auto_add_executable(teleop_manager_node
 ament_auto_add_executable(keyboard_to_joy_node
   src/keyboard_to_joy_node.cpp
 )
+
+ament_auto_add_executable(keyboard_x11_to_joy_node
+  src/keyboard_x11_to_joy_node.cpp
+)
+target_include_directories(keyboard_x11_to_joy_node PRIVATE ${X11_INCLUDE_DIR})
+target_link_libraries(keyboard_x11_to_joy_node ${X11_LIBRARIES})
 
 ament_auto_package(INSTALL_TO_SHARE
   config

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/config/teleop.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/config/teleop.param.yaml
@@ -20,6 +20,10 @@
     start_button_index:   7   # R2 ボタンで start=true
     stop_button_index:    6   # L2 ボタンで start=false
 
+    # --- アクセル/ステアリング軸インデックス ---
+    speed_axis_index:     1   # アクセル (axes[1] 左スティック縦)
+    steer_axis_index:     0   # ステアリング (axes[0] 左スティック横)
+
     # --- 十字キー（D-pad）軸インデックス ---
     dpad_lr_axis_index:   6   # 左右 (axes[6])
     dpad_ud_axis_index:   7   # 上下 (axes[7])

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/config/teleop.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/config/teleop.param.yaml
@@ -12,6 +12,10 @@
     awsim_button_index:   1   # ○ボタンでAWSIMモード
     reset_button_index:   0   # ×ボタンでリセット
 
+    # --- ギア切替ボタン (DRIVE=2 / REVERSE=20 のみ) ---
+    drive_button_index:   5   # R1 で DRIVE(前進)
+    reverse_button_index: 4   # L1 で REVERSE(後進)
+
     # --- start/stop トリガボタン ---
     start_button_index:   7   # R2 ボタンで start=true
     stop_button_index:    6   # L2 ボタンで start=false

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/config/teleop.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/config/teleop.param.yaml
@@ -16,6 +16,9 @@
     drive_button_index:   5   # R1 で DRIVE(前進)
     reverse_button_index: 4   # L1 で REVERSE(後進)
 
+    # --- AWSIM ターボブースト (押すたびに発火) ---
+    boost_button_index:   8   # /awsim/cmd へ [1.0]→[0.0] を送信(AWSIM側トグル)
+
     # --- start/stop トリガボタン ---
     start_button_index:   7   # R2 ボタンで start=true
     stop_button_index:    6   # L2 ボタンで start=false

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/include/teleop_manager/teleop_manager_node.hpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/include/teleop_manager/teleop_manager_node.hpp
@@ -21,6 +21,7 @@ public:
 private:
   bool check_button_press(bool curr, bool &prev_flag);
   void publish_gear(uint8_t command);
+  void publish_turbo();
 
   // Callbacks
   void status_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg);
@@ -36,6 +37,7 @@ private:
   rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr gear_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr                trigger_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr                awsim_trigger_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr   awsim_boost_pub_;
   rclcpp::Publisher<std_msgs::msg::Empty>::SharedPtr               reset_publisher_;
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initialpose_publisher_;
   rclcpp::TimerBase::SharedPtr                                     timer_;
@@ -47,6 +49,7 @@ private:
   int start_button_index_, stop_button_index_;
   int awsim_button_index_;
   int reset_button_index_;
+  int boost_button_index_;
   int drive_button_index_, reverse_button_index_;
   int speed_axis_index_, steer_axis_index_;
   int dpad_lr_axis_index_;
@@ -72,6 +75,7 @@ private:
   bool prev_speed_scale_dec_pressed_;
   bool prev_drive_button_pressed_;
   bool prev_reverse_button_pressed_;
+  bool prev_boost_button_pressed_;
 };
 
 #endif  // TELEOP_MANAGER_NODE_HPP_

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/include/teleop_manager/teleop_manager_node.hpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/include/teleop_manager/teleop_manager_node.hpp
@@ -48,6 +48,7 @@ private:
   int awsim_button_index_;
   int reset_button_index_;
   int drive_button_index_, reverse_button_index_;
+  int speed_axis_index_, steer_axis_index_;
   int dpad_lr_axis_index_;
   int dpad_ud_axis_index_;
   double timer_hz_;

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/include/teleop_manager/teleop_manager_node.hpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/include/teleop_manager/teleop_manager_node.hpp
@@ -7,6 +7,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
 #include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
+#include "autoware_auto_vehicle_msgs/msg/gear_command.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/empty.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
@@ -19,6 +20,7 @@ public:
 
 private:
   bool check_button_press(bool curr, bool &prev_flag);
+  void publish_gear(uint8_t command);
 
   // Callbacks
   void status_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg);
@@ -31,6 +33,7 @@ private:
   rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr ack_sub_;
   rclcpp::Subscription<std_msgs::msg::Float32MultiArray>::SharedPtr status_sub_;
   rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr drive_pub_;
+  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr gear_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr                trigger_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr                awsim_trigger_pub_;
   rclcpp::Publisher<std_msgs::msg::Empty>::SharedPtr               reset_publisher_;
@@ -44,6 +47,7 @@ private:
   int start_button_index_, stop_button_index_;
   int awsim_button_index_;
   int reset_button_index_;
+  int drive_button_index_, reverse_button_index_;
   int dpad_lr_axis_index_;
   int dpad_ud_axis_index_;
   double timer_hz_;
@@ -65,6 +69,8 @@ private:
   bool prev_steer_scale_dec_pressed_;
   bool prev_speed_scale_inc_pressed_;
   bool prev_speed_scale_dec_pressed_;
+  bool prev_drive_button_pressed_;
+  bool prev_reverse_button_pressed_;
 };
 
 #endif  // TELEOP_MANAGER_NODE_HPP_

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/launch/teleop_manager.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/launch/teleop_manager.launch.xml
@@ -4,15 +4,29 @@
   <arg name="self_control_topic" default="/ackermann_cmd"/>
   <arg name="vehicle_control_topic" default="/control/command/control_cmd"/>
   <arg name="trigger_topic" default="/rosbag2_recorder/trigger"/>
+  <arg name="input_source" default="joy" description="Joy input source: joy | keyboard"/>
 
-  
+
   <!-- joynode -->
-  <node pkg="joy" 
-        exec="joy_node"
-        name="joy_node"
-        output="screen">
-    <param name="deadzone" value="0.05"/>
-  </node>
+  <group if="$(eval &quot;'$(var input_source)' == 'joy'&quot;)">
+    <node pkg="joy"
+          exec="joy_node"
+          name="joy_node"
+          output="screen">
+      <param name="deadzone" value="0.05"/>
+    </node>
+  </group>
+
+  <!-- keyboard -> /joy bridge (reads /dev/input/event* directly; needs the
+       container `input` group, no TTY/X11 required) -->
+  <group if="$(eval &quot;'$(var input_source)' == 'keyboard'&quot;)">
+    <node pkg="teleop_manager"
+          exec="keyboard_to_joy_node"
+          name="keyboard_to_joy_node"
+          output="screen">
+      <param from="$(var teleop_param)"/>
+    </node>
+  </group>
 
   <!-- joy manager node-->
   <node pkg="teleop_manager"

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/launch/teleop_manager.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/launch/teleop_manager.launch.xml
@@ -4,7 +4,7 @@
   <arg name="self_control_topic" default="/ackermann_cmd"/>
   <arg name="vehicle_control_topic" default="/control/command/control_cmd"/>
   <arg name="trigger_topic" default="/rosbag2_recorder/trigger"/>
-  <arg name="input_source" default="joy" description="Joy input source: joy | keyboard"/>
+  <arg name="input_source" default="joy" description="Joy input source: joy | keyboard | keyboard_x11"/>
 
 
   <!-- joynode -->
@@ -23,6 +23,17 @@
     <node pkg="teleop_manager"
           exec="keyboard_to_joy_node"
           name="keyboard_to_joy_node"
+          output="screen">
+      <param from="$(var teleop_param)"/>
+    </node>
+  </group>
+
+  <!-- keyboard (X11) -> /joy bridge (reads X server key state; use over remote
+       desktop / VNC / RDP where keys are injected into X, not evdev) -->
+  <group if="$(eval &quot;'$(var input_source)' == 'keyboard_x11'&quot;)">
+    <node pkg="teleop_manager"
+          exec="keyboard_x11_to_joy_node"
+          name="keyboard_x11_to_joy_node"
           output="screen">
       <param from="$(var teleop_param)"/>
     </node>

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/package.xml
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/package.xml
@@ -13,6 +13,7 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/keyboard_to_joy_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/keyboard_to_joy_node.cpp
@@ -1,0 +1,195 @@
+// Keyboard -> sensor_msgs/Joy bridge (evdev / OS-level key events).
+//
+// Publishes /joy so teleop_manager_node can be driven from a keyboard instead
+// of a joystick. Axis/button indices are read from the SAME parameters as
+// teleop_manager (teleop.param.yaml uses the `/**:` wildcard), so they stay in
+// sync. The MANUAL-mode button (joy_button_index) is held down at all times.
+//
+// Input is read from a Linux input device (/dev/input/event*): real OS-level
+// key press/release (EV_KEY), so simultaneous holds work and no TTY/X11 is
+// needed (only the `input` group). Pick the device with the `device_path`
+// parameter, or leave it empty to auto-detect the first device that reports the
+// W/A/S/D keys.
+//
+// Key bindings:
+//   w / s : accelerate forward / reverse   (held -> speed axis +1 / -1)
+//   a / d : steer left / right             (held -> steer axis +1 / -1)
+//   1 / 2 : gear DRIVE / REVERSE            (pulse on press)
+//   b     : turbo boost                     (pulse on press)
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joy.hpp"
+
+namespace
+{
+bool key_supported(int fd, int code)
+{
+  unsigned long bits[(KEY_MAX / (8 * sizeof(unsigned long))) + 1];
+  std::memset(bits, 0, sizeof(bits));
+  if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(bits)), bits) < 0) return false;
+  return (bits[code / (8 * sizeof(unsigned long))] >>
+          (code % (8 * sizeof(unsigned long)))) & 1UL;
+}
+}  // namespace
+
+class KeyboardToJoyNode : public rclcpp::Node
+{
+public:
+  KeyboardToJoyNode()
+  : Node("keyboard_to_joy_node")
+  {
+    // Shared with teleop_manager via teleop.param.yaml (`/**:`).
+    speed_axis_index_     = declare_parameter<int>("speed_axis_index", 1);
+    steer_axis_index_     = declare_parameter<int>("steer_axis_index", 0);
+    joy_button_index_     = declare_parameter<int>("joy_button_index", 2);
+    drive_button_index_   = declare_parameter<int>("drive_button_index", 5);
+    reverse_button_index_ = declare_parameter<int>("reverse_button_index", 4);
+    boost_button_index_   = declare_parameter<int>("boost_button_index", 8);
+
+    publish_hz_  = declare_parameter<double>("publish_hz", 50.0);
+    device_path_ = declare_parameter<std::string>("device_path", "");
+
+    n_axes_ = std::max(speed_axis_index_, steer_axis_index_) + 1;
+    n_buttons_ = std::max({joy_button_index_, drive_button_index_,
+                           reverse_button_index_, boost_button_index_}) + 1;
+
+    joy_pub_ = create_publisher<sensor_msgs::msg::Joy>("/joy", 10);
+
+    open_device();
+
+    timer_ = create_wall_timer(
+      std::chrono::duration<double>(1.0 / publish_hz_),
+      std::bind(&KeyboardToJoyNode::tick, this));
+
+    RCLCPP_INFO(get_logger(),
+      "keyboard_to_joy started (manual mode always held). "
+      "Keys: w/s accel, a/d steer, 1/2 gear D/R, b boost.");
+  }
+
+  ~KeyboardToJoyNode() override
+  {
+    if (fd_ >= 0) close(fd_);
+  }
+
+private:
+  void open_device()
+  {
+    if (!device_path_.empty()) {
+      fd_ = open(device_path_.c_str(), O_RDONLY | O_NONBLOCK);
+      if (fd_ < 0) {
+        RCLCPP_ERROR(get_logger(), "Failed to open device_path '%s'; keyboard disabled.",
+                     device_path_.c_str());
+      } else {
+        RCLCPP_INFO(get_logger(), "Using keyboard device: %s", device_path_.c_str());
+      }
+      return;
+    }
+
+    // Auto-detect: first /dev/input/event* that reports W/A/S/D keys.
+    DIR * dir = opendir("/dev/input");
+    if (!dir) {
+      RCLCPP_ERROR(get_logger(), "Cannot open /dev/input; keyboard disabled.");
+      return;
+    }
+    struct dirent * ent;
+    while ((ent = readdir(dir)) != nullptr) {
+      if (std::strncmp(ent->d_name, "event", 5) != 0) continue;
+      const std::string path = std::string("/dev/input/") + ent->d_name;
+      int fd = open(path.c_str(), O_RDONLY | O_NONBLOCK);
+      if (fd < 0) continue;
+      if (key_supported(fd, KEY_W) && key_supported(fd, KEY_A) &&
+          key_supported(fd, KEY_S) && key_supported(fd, KEY_D)) {
+        fd_ = fd;
+        RCLCPP_INFO(get_logger(), "Auto-detected keyboard device: %s", path.c_str());
+        break;
+      }
+      close(fd);
+    }
+    closedir(dir);
+    if (fd_ < 0) {
+      RCLCPP_ERROR(get_logger(),
+        "No keyboard device found under /dev/input; set the 'device_path' param.");
+    }
+  }
+
+  void tick()
+  {
+    read_events();
+
+    sensor_msgs::msg::Joy joy;
+    joy.header.stamp = now();
+    joy.axes.assign(n_axes_, 0.0f);
+    joy.buttons.assign(n_buttons_, 0);
+
+    // Held W/A/S/D map straight to axis values (opposite keys cancel).
+    joy.axes[speed_axis_index_] = (w_ ? 1.0f : 0.0f) + (s_ ? -1.0f : 0.0f);
+    joy.axes[steer_axis_index_] = (a_ ? 1.0f : 0.0f) + (d_ ? -1.0f : 0.0f);
+
+    // Manual mode is always engaged.
+    joy.buttons[joy_button_index_] = 1;
+
+    // One-shot gear/boost pulses asserted for a single message.
+    for (int idx : pulse_buttons_) {
+      if (idx >= 0 && idx < n_buttons_) joy.buttons[idx] = 1;
+    }
+    pulse_buttons_.clear();
+
+    joy_pub_->publish(joy);
+  }
+
+  void read_events()
+  {
+    if (fd_ < 0) return;
+    input_event ev;
+    while (read(fd_, &ev, sizeof(ev)) == sizeof(ev)) {
+      if (ev.type != EV_KEY) continue;
+      const bool down = (ev.value != 0);  // 1=press, 2=repeat
+      switch (ev.code) {
+        case KEY_W: w_ = down; break;
+        case KEY_S: s_ = down; break;
+        case KEY_A: a_ = down; break;
+        case KEY_D: d_ = down; break;
+        case KEY_1: if (ev.value == 1) pulse_buttons_.push_back(drive_button_index_); break;
+        case KEY_2: if (ev.value == 1) pulse_buttons_.push_back(reverse_button_index_); break;
+        case KEY_B: if (ev.value == 1) pulse_buttons_.push_back(boost_button_index_); break;
+        default: break;
+      }
+    }
+  }
+
+  // Params (shared with teleop_manager)
+  int speed_axis_index_, steer_axis_index_;
+  int joy_button_index_, drive_button_index_, reverse_button_index_, boost_button_index_;
+  double publish_hz_;
+  std::string device_path_;
+  int n_axes_, n_buttons_;
+
+  // State
+  bool w_{false}, a_{false}, s_{false}, d_{false};
+  std::vector<int> pulse_buttons_;
+
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  int fd_{-1};
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<KeyboardToJoyNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/keyboard_x11_to_joy_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/keyboard_x11_to_joy_node.cpp
@@ -1,0 +1,145 @@
+// Keyboard -> sensor_msgs/Joy bridge (X11 / display-server key state).
+//
+// Same role as keyboard_to_joy_node, but reads key state from the X server via
+// XQueryKeymap instead of /dev/input/event*. Use this over remote desktop
+// (VNC/RDP/xrdp), where keystrokes are injected into the X server and never
+// reach the kernel evdev layer. Requires DISPLAY + X authority; needs no TTY
+// and no `input` group.
+//
+// Axis/button indices come from the SAME parameters as teleop_manager
+// (teleop.param.yaml `/**:`). The MANUAL-mode button is held at all times.
+//
+// Key bindings:
+//   w / s : accelerate forward / reverse   (held -> speed axis +1 / -1)
+//   a / d : steer left / right             (held -> steer axis +1 / -1)
+//   1 / 2 : gear DRIVE / REVERSE            (pulse on press)
+//   b     : turbo boost                     (pulse on press)
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joy.hpp"
+
+// X11 headers define macros (None, Status, Bool, ...) that corrupt the parsing
+// of ROS headers, so include them LAST, after rclcpp/sensor_msgs are parsed.
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+
+class KeyboardX11ToJoyNode : public rclcpp::Node
+{
+public:
+  KeyboardX11ToJoyNode()
+  : Node("keyboard_x11_to_joy_node")
+  {
+    // Shared with teleop_manager via teleop.param.yaml (`/**:`).
+    speed_axis_index_     = declare_parameter<int>("speed_axis_index", 1);
+    steer_axis_index_     = declare_parameter<int>("steer_axis_index", 0);
+    joy_button_index_     = declare_parameter<int>("joy_button_index", 2);
+    drive_button_index_   = declare_parameter<int>("drive_button_index", 5);
+    reverse_button_index_ = declare_parameter<int>("reverse_button_index", 4);
+    boost_button_index_   = declare_parameter<int>("boost_button_index", 8);
+
+    publish_hz_ = declare_parameter<double>("publish_hz", 50.0);
+
+    n_axes_ = std::max(speed_axis_index_, steer_axis_index_) + 1;
+    n_buttons_ = std::max({joy_button_index_, drive_button_index_,
+                           reverse_button_index_, boost_button_index_}) + 1;
+
+    joy_pub_ = create_publisher<sensor_msgs::msg::Joy>("/joy", 10);
+
+    display_ = XOpenDisplay(nullptr);
+    if (!display_) {
+      RCLCPP_ERROR(get_logger(),
+        "Cannot open X display (is DISPLAY/XAUTHORITY set?); keyboard disabled.");
+    } else {
+      kc_w_ = XKeysymToKeycode(display_, XK_w);
+      kc_s_ = XKeysymToKeycode(display_, XK_s);
+      kc_a_ = XKeysymToKeycode(display_, XK_a);
+      kc_d_ = XKeysymToKeycode(display_, XK_d);
+      kc_1_ = XKeysymToKeycode(display_, XK_1);
+      kc_2_ = XKeysymToKeycode(display_, XK_2);
+      kc_b_ = XKeysymToKeycode(display_, XK_b);
+      RCLCPP_INFO(get_logger(),
+        "keyboard_x11_to_joy started on display '%s'. "
+        "Keys: w/s accel, a/d steer, 1/2 gear D/R, b boost.",
+        XDisplayString(display_));
+    }
+
+    timer_ = create_wall_timer(
+      std::chrono::duration<double>(1.0 / publish_hz_),
+      std::bind(&KeyboardX11ToJoyNode::tick, this));
+  }
+
+  ~KeyboardX11ToJoyNode() override
+  {
+    if (display_) XCloseDisplay(display_);
+  }
+
+private:
+  static bool pressed(const char keys[32], KeyCode kc)
+  {
+    return kc != 0 && (keys[kc / 8] & (1 << (kc % 8)));
+  }
+
+  void tick()
+  {
+    sensor_msgs::msg::Joy joy;
+    joy.header.stamp = now();
+    joy.axes.assign(n_axes_, 0.0f);
+    joy.buttons.assign(n_buttons_, 0);
+    joy.buttons[joy_button_index_] = 1;  // manual mode always engaged
+
+    if (display_) {
+      char keys[32];
+      XQueryKeymap(display_, keys);
+
+      const bool w = pressed(keys, kc_w_);
+      const bool s = pressed(keys, kc_s_);
+      const bool a = pressed(keys, kc_a_);
+      const bool d = pressed(keys, kc_d_);
+      joy.axes[speed_axis_index_] = (w ? 1.0f : 0.0f) + (s ? -1.0f : 0.0f);
+      joy.axes[steer_axis_index_] = (a ? 1.0f : 0.0f) + (d ? -1.0f : 0.0f);
+
+      // Gear/boost pulse once on the press edge.
+      pulse_on_edge(pressed(keys, kc_1_), prev_1_, drive_button_index_, joy);
+      pulse_on_edge(pressed(keys, kc_2_), prev_2_, reverse_button_index_, joy);
+      pulse_on_edge(pressed(keys, kc_b_), prev_b_, boost_button_index_, joy);
+    }
+
+    joy_pub_->publish(joy);
+  }
+
+  void pulse_on_edge(bool now_pressed, bool & prev, int button_index,
+                     sensor_msgs::msg::Joy & joy)
+  {
+    if (now_pressed && !prev && button_index >= 0 && button_index < n_buttons_) {
+      joy.buttons[button_index] = 1;
+    }
+    prev = now_pressed;
+  }
+
+  // Params (shared with teleop_manager)
+  int speed_axis_index_, steer_axis_index_;
+  int joy_button_index_, drive_button_index_, reverse_button_index_, boost_button_index_;
+  double publish_hz_;
+  int n_axes_, n_buttons_;
+
+  // X11
+  Display * display_{nullptr};
+  KeyCode kc_w_{0}, kc_s_{0}, kc_a_{0}, kc_d_{0}, kc_1_{0}, kc_2_{0}, kc_b_{0};
+  bool prev_1_{false}, prev_2_{false}, prev_b_{false};
+
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<KeyboardX11ToJoyNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/teleop_manager_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/teleop_manager_node.cpp
@@ -22,7 +22,9 @@ TeleopManagerNode::TeleopManagerNode()
   prev_steer_scale_inc_pressed_(false),
   prev_steer_scale_dec_pressed_(false),
   prev_speed_scale_inc_pressed_(false),
-  prev_speed_scale_dec_pressed_(false)
+  prev_speed_scale_dec_pressed_(false),
+  prev_drive_button_pressed_(false),
+  prev_reverse_button_pressed_(false)
 {
   this->set_parameter(rclcpp::Parameter("use_sim_time", true));
 
@@ -35,6 +37,8 @@ TeleopManagerNode::TeleopManagerNode()
   declare_parameter<int>("stop_button_index",  8);
   declare_parameter<int>("awsim_button_index", 2);
   declare_parameter<int>("reset_button_index", 7);
+  declare_parameter<int>("drive_button_index", 5);    // ギア: DRIVE(前進=2)
+  declare_parameter<int>("reverse_button_index", 4);  // ギア: REVERSE(後進=20)
   declare_parameter<double>("timer_hz", 40.0);
   declare_parameter<double>("joy_timeout_sec", 0.5);
   declare_parameter<int>("dpad_lr_axis_index", 6); 
@@ -57,6 +61,8 @@ TeleopManagerNode::TeleopManagerNode()
   get_parameter("stop_button_index", stop_button_index_);
   get_parameter("awsim_button_index", awsim_button_index_);
   get_parameter("reset_button_index", reset_button_index_);
+  get_parameter("drive_button_index", drive_button_index_);
+  get_parameter("reverse_button_index", reverse_button_index_);
   get_parameter("timer_hz", timer_hz_);
   get_parameter("joy_timeout_sec", joy_timeout_sec_);
   get_parameter("dpad_lr_axis_index", dpad_lr_axis_index_);
@@ -86,6 +92,7 @@ TeleopManagerNode::TeleopManagerNode()
     "/admin/awsim/status", 10, std::bind(&TeleopManagerNode::status_callback, this, _1));
 
   drive_pub_   = create_publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>("/control/command/control_cmd", 10);
+  gear_pub_    = create_publisher<autoware_auto_vehicle_msgs::msg::GearCommand>("/control/command/gear_cmd", 10);
   trigger_pub_ = create_publisher<std_msgs::msg::Bool>("/rosbag2_recorder/trigger", 10);
 
   awsim_trigger_pub_ = create_publisher<std_msgs::msg::Bool>("/awsim/control_mode_request_topic", 10);
@@ -116,6 +123,14 @@ void TeleopManagerNode::status_callback(const std_msgs::msg::Float32MultiArray::
   if (msg->data.size() >= 2) {
     current_lap_ = msg->data[1];
   }
+}
+
+void TeleopManagerNode::publish_gear(uint8_t command)
+{
+  autoware_auto_vehicle_msgs::msg::GearCommand gear;
+  gear.stamp = this->get_clock()->now();
+  gear.command = command;
+  gear_pub_->publish(gear);
 }
 
 void TeleopManagerNode::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg)
@@ -156,6 +171,20 @@ void TeleopManagerNode::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg)
     // pose_msg->header.stamp = this->get_clock()->now();
     initialpose_publisher_->publish(std::move(pose_msg));
     RCLCPP_INFO(get_logger(), "Published initial pose to /initialpose");
+  }
+
+  // 1b) Gear selection (DRIVE / REVERSE only, with debounce)
+  bool curr_drive_button = (static_cast<int>(msg->buttons.size()) > drive_button_index_
+                            && msg->buttons[drive_button_index_] == 1);
+  bool curr_reverse_button = (static_cast<int>(msg->buttons.size()) > reverse_button_index_
+                              && msg->buttons[reverse_button_index_] == 1);
+  if (check_button_press(curr_drive_button, prev_drive_button_pressed_)) {
+    publish_gear(autoware_auto_vehicle_msgs::msg::GearCommand::DRIVE);     // 2
+    RCLCPP_INFO(get_logger(), "Gear -> DRIVE");
+  }
+  if (check_button_press(curr_reverse_button, prev_reverse_button_pressed_)) {
+    publish_gear(autoware_auto_vehicle_msgs::msg::GearCommand::REVERSE);   // 20
+    RCLCPP_INFO(get_logger(), "Gear -> REVERSE");
   }
 
   // 2) Mode selection

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/teleop_manager_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/teleop_manager_node.cpp
@@ -24,7 +24,8 @@ TeleopManagerNode::TeleopManagerNode()
   prev_speed_scale_inc_pressed_(false),
   prev_speed_scale_dec_pressed_(false),
   prev_drive_button_pressed_(false),
-  prev_reverse_button_pressed_(false)
+  prev_reverse_button_pressed_(false),
+  prev_boost_button_pressed_(false)
 {
   this->set_parameter(rclcpp::Parameter("use_sim_time", true));
 
@@ -39,6 +40,7 @@ TeleopManagerNode::TeleopManagerNode()
   declare_parameter<int>("reset_button_index", 7);
   declare_parameter<int>("drive_button_index", 5);    // ギア: DRIVE(前進=2)
   declare_parameter<int>("reverse_button_index", 4);  // ギア: REVERSE(後進=20)
+  declare_parameter<int>("boost_button_index", 8);    // AWSIM ターボブースト(トグル)
   declare_parameter<double>("timer_hz", 40.0);
   declare_parameter<double>("joy_timeout_sec", 0.5);
   declare_parameter<int>("speed_axis_index", 1);  // アクセル: 左スティック縦
@@ -65,6 +67,7 @@ TeleopManagerNode::TeleopManagerNode()
   get_parameter("reset_button_index", reset_button_index_);
   get_parameter("drive_button_index", drive_button_index_);
   get_parameter("reverse_button_index", reverse_button_index_);
+  get_parameter("boost_button_index", boost_button_index_);
   get_parameter("timer_hz", timer_hz_);
   get_parameter("joy_timeout_sec", joy_timeout_sec_);
   get_parameter("speed_axis_index", speed_axis_index_);
@@ -100,6 +103,7 @@ TeleopManagerNode::TeleopManagerNode()
   trigger_pub_ = create_publisher<std_msgs::msg::Bool>("/rosbag2_recorder/trigger", 10);
 
   awsim_trigger_pub_ = create_publisher<std_msgs::msg::Bool>("/awsim/control_mode_request_topic", 10);
+  awsim_boost_pub_ = create_publisher<std_msgs::msg::Float32MultiArray>("/awsim/cmd", 10);
 
   reset_publisher_ = create_publisher<std_msgs::msg::Empty>("/admin/awsim/reset", 10);
   initialpose_publisher_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/initialpose", 10);
@@ -135,6 +139,15 @@ void TeleopManagerNode::publish_gear(uint8_t command)
   gear.stamp = this->get_clock()->now();
   gear.command = command;
   gear_pub_->publish(gear);
+}
+
+void TeleopManagerNode::publish_turbo()
+{
+  std_msgs::msg::Float32MultiArray msg;
+  msg.data = {1.0f};
+  awsim_boost_pub_->publish(msg);
+  msg.data = {0.0f};
+  awsim_boost_pub_->publish(msg);
 }
 
 void TeleopManagerNode::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg)
@@ -189,6 +202,14 @@ void TeleopManagerNode::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg)
   if (check_button_press(curr_reverse_button, prev_reverse_button_pressed_)) {
     publish_gear(autoware_auto_vehicle_msgs::msg::GearCommand::REVERSE);   // 20
     RCLCPP_INFO(get_logger(), "Gear -> REVERSE");
+  }
+
+  // 1c) AWSIM turbo boost (send [1.0] then [0.0] on each press)
+  bool curr_boost_button = (static_cast<int>(msg->buttons.size()) > boost_button_index_
+                            && msg->buttons[boost_button_index_] == 1);
+  if (check_button_press(curr_boost_button, prev_boost_button_pressed_)) {
+    publish_turbo();
+    RCLCPP_INFO(get_logger(), "Turbo boost command published");
   }
 
   // 2) Mode selection

--- a/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/teleop_manager_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_tools/teleop_manager/src/teleop_manager_node.cpp
@@ -41,7 +41,9 @@ TeleopManagerNode::TeleopManagerNode()
   declare_parameter<int>("reverse_button_index", 4);  // ギア: REVERSE(後進=20)
   declare_parameter<double>("timer_hz", 40.0);
   declare_parameter<double>("joy_timeout_sec", 0.5);
-  declare_parameter<int>("dpad_lr_axis_index", 6); 
+  declare_parameter<int>("speed_axis_index", 1);  // アクセル: 左スティック縦
+  declare_parameter<int>("steer_axis_index", 0);  // ステアリング: 左スティック横
+  declare_parameter<int>("dpad_lr_axis_index", 6);
   declare_parameter<int>("dpad_ud_axis_index", 7); 
 
   declare_parameter<std::string>("reset_frame_id", "map");
@@ -65,6 +67,8 @@ TeleopManagerNode::TeleopManagerNode()
   get_parameter("reverse_button_index", reverse_button_index_);
   get_parameter("timer_hz", timer_hz_);
   get_parameter("joy_timeout_sec", joy_timeout_sec_);
+  get_parameter("speed_axis_index", speed_axis_index_);
+  get_parameter("steer_axis_index", steer_axis_index_);
   get_parameter("dpad_lr_axis_index", dpad_lr_axis_index_);
   get_parameter("dpad_ud_axis_index", dpad_ud_axis_index_);
 
@@ -203,8 +207,8 @@ void TeleopManagerNode::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg)
 
   // 3) Calculate speed/steer in Joy mode (using current scales)
   if (joy_active_) {
-    double raw_speed = (static_cast<int>(msg->axes.size()) > 1 ? msg->axes[1] : 0.0);
-    double raw_steer = (static_cast<int>(msg->axes.size()) > 3 ? msg->axes[3] : 0.0);
+    double raw_speed = (static_cast<int>(msg->axes.size()) > speed_axis_index_ ? msg->axes[speed_axis_index_] : 0.0);
+    double raw_steer = (static_cast<int>(msg->axes.size()) > steer_axis_index_ ? msg->axes[steer_axis_index_] : 0.0);
     joy_speed_ = raw_speed * speed_scale_;
     joy_steer_ = raw_steer * steer_scale_;
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ x-autoware-base: &autoware-base
     - /dev/dri
     - /dev/video0
     - /dev/input
+  group_add:
+    # Read /dev/input/event* (joy_node/SDL2) as non-root user. GID from host `input` group.
+    - "${HOST_GID_INPUT:-104}"
   working_dir: /aichallenge
 
 x-autoware-rosbag-base: &autoware-rosbag-base

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -50,12 +50,14 @@ else
     echo "[INFO] No NVIDIA GPU detected → running on CPU"
 fi
 
-# Join render/video groups for /dev/dri access.
+# Join render/video groups for /dev/dri access, input group for /dev/input/event* (joy_node).
 gid_render="$(getent group render | cut -d: -f3)"
 gid_video="$(getent group video | cut -d: -f3)"
+gid_input="$(getent group input | cut -d: -f3)"
 group_add_opts=""
 [ -n "${gid_render}" ] && group_add_opts="${group_add_opts} --group-add ${gid_render}"
 [ -n "${gid_video}" ] && group_add_opts="${group_add_opts} --group-add ${gid_video}"
+[ -n "${gid_input}" ] && group_add_opts="${group_add_opts} --group-add ${gid_input}"
 
 ts="$(date +%Y%m%d-%H%M%S)"
 LOG_FILE="output/docker/${ts}-docker_run-$$.log"

--- a/setup.bash
+++ b/setup.bash
@@ -968,7 +968,9 @@ ensure_env() {
     upsert_env_var HOST_GID "$(id -g)"
     gid="$(getent group dialout | cut -d: -f3)"
     [ -n "${gid}" ] && upsert_env_var HOST_GID_DIALOUT "${gid}"
-    log "${OK} Set host UID/GID + dialout GID in .env"
+    gid="$(getent group input | cut -d: -f3)"
+    [ -n "${gid}" ] && upsert_env_var HOST_GID_INPUT "${gid}"
+    log "${OK} Set host UID/GID + dialout/input GID in .env"
 }
 
 # Host DDS tuning (CycloneDDS): persist rmem_max + multicast on lo


### PR DESCRIPTION
## 内容

teleop_managerの変更

- 修正: コンテナ内部でジョイスティックが認識されない問題を修正しました
- 修正: joyconのアクセル、ステアリング用の軸indexのパラメータ化
- 追加: DRIVEとREVERSEギアの切り替えコマンドを追加しました
- 追加: ターボブーストコマンドを追加しました
- 追加: キーボード操作に対応しました
- 追加: リモートデスクトップ越しでのキーボード操作に対応しました（ただし、リモート + Waylandは未対応）
- 追加設定: `teleop_manager.launch.xml` に `input_source` argを追加
  - `"joycon"` (default)
  - `"keyboard"`
  - `"keyboard_x11"`

Dockerコンテナ関係の変更（teleopとは無関係の変更ですが、動作確認の際に必要だったため本PRで一緒に入れます）

- 変更: make autoware-bashは従来は既存コンテナへのアタッチであり、./docker_exec をラップしているだけでした。本変更で、bashだけを実行する新規コンテナを起動するように修正しました
- Dockerコンテナ内部でsudoコマンドが使用できなかった問題を修正しました

## テスト

### regressionテスト

クリーンな状態から本ブランチ上で以下の操作を行う

- [x] `./setup.bash bootstrap`   して本ブランチを選択してセットアップ処理が全て動くこと
- [x] `make dev` が正常に起動すること
- [x] `./create_submit_file.bash && ./docker_run.sh eval && make eval` が正常に起動すること
- [x] `make dev4` が正常に起動すること

### joycon操作のテスト

`launch/reference.launch.xml` で `arg name="control_method" default="joycon"` に設定して、`make dev` で起動

- [x] 従来通りjoyconで、操作できること
- [x] 8ボタン押しで、ターボブーストが出来ること
- [x] 再度8ボタン押しで、ターボブーストが出来ること
- [x] 4ボタン押しで、ギアがREVERSEになること
- [x] 5ボタン押しで、ギアがDRIVEになること

### キーボード操作のテスト

`launch/reference.launch.xml` で `arg name="control_method" default="joycon"` かつ `teleop_manager.launch.xml` で `arg name="input_source" default="keyboard"` に設定して、`make dev` で起動

- [x] wsadキー押しで、操作出来ること
- [x] bキー押しで。ターボブーストが出来ること
- [x] 再度bキー押しで、ターボブーストが出来ること
- [x] 2キー押しで、ギアがREVERSEになること
- [x] 1キー押しで、ギアがDRIVEになること

### キーボード操作のテスト（リモートデスクトップ）

リモートデスクトップでリモートPCに接続し、 `launch/reference.launch.xml` で `arg name="control_method" default="joycon"` かつ `teleop_manager.launch.xml` で `arg name="input_source" default="keyboard_x11"` に設定して、`make dev` で起動

- [x] wsadキー押しで、操作出来ること
- [x] bキー押しで。ターボブーストが出来ること
- [x] 再度bキー押しで、ターボブーストが出来ること
- [x] 2キー押しで、ギアがREVERSEになること
- [x] 1キー押しで、ギアがDRIVEになること

### その他

- [x] `make dev` した後に、 `make autoware-attach` で既存コンテナにアタッチしてbashが起動すること
- [x] `make down_all` した後に、 `make autoware-bash` で新規コンテナが作成されてbashが起動すること
- [x]  コンテナ内で、 `sudo apt update` コマンドが成功すること