### PR TITLE
fix: acceleration for tiny_lidar_net

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/tiny_lidar_net_controller/config/tiny_lidar_net_node.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/tiny_lidar_net_controller/config/tiny_lidar_net_node.param.yaml
@@ -10,6 +10,6 @@
 
     max_range: 30.0              # LiDARの最大レンジ（メートル）
     control_mode: "fixed"          # "ai" または "fixed"
-    acceleration: 0.3            # 固定加速度コマンド mode:fixed の場合に使用
+    acceleration: 0.6            # 固定加速度コマンド mode:fixed の場合に使用
 
     debug: false


### PR DESCRIPTION
# 変更内容

- tiny_lidar_netで使われているfixed加速度は `acceleration: 0.3` です。しかし、0.3だとAWSIM上で車両が動き出しませんでした
- PilotNetと同様に加速度設定を0.6にします