### PR TITLE
fix: prune old numbered AWSIM backups after a successful download

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -920,9 +920,12 @@ PY
         # Keep only the newest numbered backup (AWSIM_<n>); unlimited backups have
         # piled up to tens of GB. Pruned only after the new binary is confirmed.
         local keep="${AWSIM_BACKUP_KEEP:-1}"
-        local n
-        for n in $(ls -d "${awsim_dir}_"[0-9]* 2>/dev/null |
-            sed -E "s/^.*_([0-9]+)$/\1/" | sort -rn | tail -n +$((keep + 1))); do
+        local d n numbers=""
+        for d in "${awsim_dir}_"[0-9]*; do
+            n="${d##*_}"
+            [ -e "$d" ] && [[ $n =~ ^[0-9]+$ ]] && numbers="${numbers}${n}"$'\n'
+        done
+        for n in $(printf '%s' "$numbers" | sort -rn | tail -n +$((keep + 1))); do
             log "${INFO} Pruning old AWSIM backup: ${awsim_dir}_${n}"
             rm -rf "${awsim_dir}_${n}"
         done

--- a/setup.bash
+++ b/setup.bash
@@ -917,6 +917,15 @@ PY
     if [ -f "$awsim_bin" ]; then
         chmod +x "$awsim_bin" || true
         log "${OK} AWSIM extracted: ${awsim_bin}"
+        # Keep only the newest numbered backup (AWSIM_<n>); unlimited backups have
+        # piled up to tens of GB. Pruned only after the new binary is confirmed.
+        local keep="${AWSIM_BACKUP_KEEP:-1}"
+        local n
+        for n in $(ls -d "${awsim_dir}_"[0-9]* 2>/dev/null |
+            sed -E "s/^.*_([0-9]+)$/\1/" | sort -rn | tail -n +$((keep + 1))); do
+            log "${INFO} Pruning old AWSIM backup: ${awsim_dir}_${n}"
+            rm -rf "${awsim_dir}_${n}"
+        done
     else
         warn "${WARN} AWSIM extracted but binary not found at expected path: ${awsim_bin}"
         warn "${INFO} Inspect: ls -la ${dest_dir}"


### PR DESCRIPTION
## 概要

`setup.bash download awsim` は既存の `AWSIM/` を毎回 `AWSIM_<n>` に退避しますが、剪定が無いため無制限に堆積します。手元環境では `aichallenge/simulator/` が **32ディレクトリ・20GB**(1個 632MB)まで膨張していました。

- ダウンロード・展開が成功しバイナリ確認が取れた**後**に、番号付きバックアップ(`AWSIM_<数字>`)を最新 `AWSIM_BACKUP_KEEP` 個(既定1)だけ残して削除。
- 失敗時は剪定しない(唯一の正常コピーを消さない)。
- 手動退避と思われる `AWSIM_`/`AWSIM__` 等のアンダースコア形式には触れません(数字パターン限定)。

既存の堆積分はこの修正では消えません。手動掃除する場合:
`ls -d aichallenge/simulator/AWSIM_* | xargs rm -rf`(現行 `AWSIM/` は残ります)

## テスト

- サンドボックスで dry-run: `AWSIM_1,2,3,10` + `AWSIM_`/`AWSIM__` を用意 → `AWSIM_10`(最新)のみ残り 1,2,3 を削除、アンダースコア形式と本体は不触であることを確認
- pre-commit(shellcheck / shfmt)パス