### PR TITLE
chore: print host-relative log dir in make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,13 @@ autoware-build:
 # run autoware for vehicle
 autoware-vehicle:
 	@echo "Start Autoware for Vehicle"
+	@echo "Log dir: .$(LOG_DIR)"
 	LOG_DIR=$(LOG_DIR) RUN_MODE=vehicle docker compose up -d autoware
 
 # run autoware for simulator
 autoware-simulator:
 	@echo "Start Autoware for AWSIM"
+	@echo "Log dir: .$(LOG_DIR)"
 	LOG_DIR=$(LOG_DIR) RUN_MODE=awsim docker compose up -d autoware
 
 # autoware command service use ROS_DOMAIN_ID from .env
@@ -57,6 +59,7 @@ awsim-request-reset:
 # run simulator (docker compose up -d simulator)
 simulator:
 	@echo "Start AWSIM (SIM_MODE=$(SIM_MODE))"
+	@echo "Log dir: .$(LOG_DIR)"
 	LOG_DIR=$(LOG_DIR) SIM_MODE="$(SIM_MODE)" ROS_DOMAIN_ID=0 docker compose up -d simulator
 
 # racing kart (docker compose up -d driver)


### PR DESCRIPTION
## 概要

`make dev` などの実行時、ログ出力先がコンテナ内パス `/output/<timestamp>` としか分からず、ホスト側でログファイルを見つけにくかったため、起動時にホストのカレントディレクトリからの相対パス(`./output/<timestamp>`)を表示するようにしました。

## 変更内容

- `simulator` / `autoware-simulator` / `autoware-vehicle` ターゲットに `Log dir: ./output/<timestamp>` の echo を追加(3行のみ)

## 表示例

before
```
Start AWSIM (SIM_MODE=dev)
# LOG_DIRがアクセスできないpath
LOG_DIR=/output/20260714-181138 SIM_MODE="dev" ROS_DOMAIN_ID=0 docker compose up -d simulator
[+] up 1/1
 ✔ Container aichallenge-racingkart-simulator-1 Started                            1.6s
Start Autoware for AWSIM
LOG_DIR=/output/20260714-181138 RUN_MODE=awsim docker compose up -d autoware
[+] up 1/1
 ✔ Container aichallenge-racingkart-autoware-1 Started                             0.5s
Start dev simulation (AWSIM + Autoware)
To stop: make down  (docker compose down --remove-orphans)
```

after
```
Start AWSIM (SIM_MODE=dev)
Log dir: ./output/20260714-181138
LOG_DIR=/output/20260714-181138 SIM_MODE="dev" ROS_DOMAIN_ID=0 docker compose up -d simulator
[+] up 1/1
 ✔ Container aichallenge-racingkart-simulator-1 Started                            1.6s
Start Autoware for AWSIM
Log dir: ./output/20260714-181138
LOG_DIR=/output/20260714-181138 RUN_MODE=awsim docker compose up -d autoware
[+] up 1/1
 ✔ Container aichallenge-racingkart-autoware-1 Started                             0.5s
Start dev simulation (AWSIM + Autoware)
To stop: make down  (docker compose down --remove-orphans)
```

