### PR TITLE
feat(simulator_scripts): enable start-random and disable wall-recovery in parallel.sh

### DIFF
--- a/aichallenge/simulator_scripts/README.md
+++ b/aichallenge/simulator_scripts/README.md
@@ -30,7 +30,7 @@ make eval → run_evaluation.bash → evaluation.launch.xml
 |---|---|---|---|
 | `eval.sh` | 評価 | - | 1台 / 6 laps / 600s / count開始 / handicap・wall-recovery・ranking off |
 | `dev.sh` | 開発 | 車両数 N（既定 1） | unlimited laps・timeout / count開始 / wall-recovery on / handicap・ranking off |
-| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・wall-recovery・ranking on |
+| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random on / wall-recovery off |
 | `gate.sh` | Safety Gate テスト | テスト番号 1/2/3/all（既定 all） | 1台。all は test1〜3 を順次実行 |
 | `sample-scenario.sh` | シナリオ指定起動 | - | `StreamingAssets/Race/official.yaml` を `--scenario` で読み込む |
 | `multiplay-server.sh` | Multiplay 専用サーバー | - | `-batchmode -nographics`、port 7777 |

--- a/aichallenge/simulator_scripts/README.md
+++ b/aichallenge/simulator_scripts/README.md
@@ -30,7 +30,7 @@ make eval → run_evaluation.bash → evaluation.launch.xml
 |---|---|---|---|
 | `eval.sh` | 評価 | - | 1台 / 6 laps / 600s / count開始 / handicap・wall-recovery・ranking off |
 | `dev.sh` | 開発 | 車両数 N（既定 1） | unlimited laps・timeout / count開始 / wall-recovery on / handicap・ranking off |
-| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random on / wall-recovery off |
+| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random off / wall-recovery off |
 | `gate.sh` | Safety Gate テスト | テスト番号 1/2/3/all（既定 all） | 1台。all は test1〜3 を順次実行 |
 | `sample-scenario.sh` | シナリオ指定起動 | - | `StreamingAssets/Race/official.yaml` を `--scenario` で読み込む |
 | `multiplay-server.sh` | Multiplay 専用サーバー | - | `-batchmode -nographics`、port 7777 |

--- a/aichallenge/simulator_scripts/parallel.sh
+++ b/aichallenge/simulator_scripts/parallel.sh
@@ -18,7 +18,6 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions off \
     --handicap on \
     --wall-recovery off \
-    --start-random on \
     --ranking on \
     -screen-fullscreen 1 \
     -screen-width 1920 \

--- a/aichallenge/simulator_scripts/parallel.sh
+++ b/aichallenge/simulator_scripts/parallel.sh
@@ -17,7 +17,8 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --sound off \
     --collisions off \
     --handicap on \
-    --wall-recovery on \
+    --wall-recovery off \
+    --start-random on \
     --ranking on \
     -screen-fullscreen 1 \
     -screen-width 1920 \


### PR DESCRIPTION
## 概要

複数台レース用スクリプト `parallel.sh` の AWSIM 起動オプションを変更する。

## 変更内容

- `parallel.sh`: `--wall-recovery` を off に変更し、`--start-random` を on で追加
- `README.md`: モード一覧表の `parallel.sh` 行を上記の設定に合わせて更新

## 背景

複数台レースではスタート位置をランダム化し、壁接触時の自動復帰は無効にして実レースに近い条件で走行させるため。