### PR TITLE
chore: disable wall recovery in dev and parallel scripts

### DIFF
--- a/aichallenge/simulator_scripts/README.md
+++ b/aichallenge/simulator_scripts/README.md
@@ -29,8 +29,8 @@ make eval → run_evaluation.bash → evaluation.launch.xml
 | スクリプト | 用途 | 引数 | 主な設定 |
 |---|---|---|---|
 | `eval.sh` | 評価 | - | 1台 / 6 laps / 600s / count開始 / handicap・wall-recovery・ranking off |
-| `dev.sh` | 開発 | 車両数 N（既定 1） | unlimited laps・timeout / count開始 / wall-recovery on / handicap・ranking off |
-| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・wall-recovery・ranking on |
+| `dev.sh` | 開発 | 車両数 N（既定 1） | unlimited laps・timeout / count開始 / handicap・wall-recovery・ranking off |
+| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random on / wall-recovery off |
 | `gate.sh` | Safety Gate テスト | テスト番号 1/2/3/all（既定 all） | 1台。all は test1〜3 を順次実行 |
 | `sample-scenario.sh` | シナリオ指定起動 | - | `StreamingAssets/Race/official.yaml` を `--scenario` で読み込む |
 | `multiplay-server.sh` | Multiplay 専用サーバー | - | `-batchmode -nographics`、port 7777 |

--- a/aichallenge/simulator_scripts/README.md
+++ b/aichallenge/simulator_scripts/README.md
@@ -30,7 +30,7 @@ make eval → run_evaluation.bash → evaluation.launch.xml
 |---|---|---|---|
 | `eval.sh` | 評価 | - | 1台 / 6 laps / 600s / count開始 / handicap・wall-recovery・ranking off |
 | `dev.sh` | 開発 | 車両数 N（既定 1） | unlimited laps・timeout / count開始 / handicap・wall-recovery・ranking off |
-| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random on / wall-recovery off |
+| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random off / wall-recovery off |
 | `gate.sh` | Safety Gate テスト | テスト番号 1/2/3/all（既定 all） | 1台。all は test1〜3 を順次実行 |
 | `sample-scenario.sh` | シナリオ指定起動 | - | `StreamingAssets/Race/official.yaml` を `--scenario` で読み込む |
 | `multiplay-server.sh` | Multiplay 専用サーバー | - | `-batchmode -nographics`、port 7777 |

--- a/aichallenge/simulator_scripts/dev.sh
+++ b/aichallenge/simulator_scripts/dev.sh
@@ -19,7 +19,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --sound off \
     --collisions on \
     --handicap off \
-    --wall-recovery on \
+    --wall-recovery off \
     --ranking off \
     --camera off \
     --lidar off

--- a/aichallenge/simulator_scripts/parallel.sh
+++ b/aichallenge/simulator_scripts/parallel.sh
@@ -18,7 +18,6 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions off \
     --handicap on \
     --wall-recovery off \
-    --start-random on \
     --ranking on \
     -screen-fullscreen 1 \
     -screen-width 1280 \

--- a/aichallenge/simulator_scripts/parallel.sh
+++ b/aichallenge/simulator_scripts/parallel.sh
@@ -21,8 +21,8 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --start-random on \
     --ranking on \
     -screen-fullscreen 1 \
-    -screen-width 1920 \
-    -screen-height 1080 \
+    -screen-width 1280 \
+    -screen-height 720 \
     -screen-quality low \
     -window-mode borderless # Unity default arg
 

--- a/aichallenge/simulator_scripts/parallel.sh
+++ b/aichallenge/simulator_scripts/parallel.sh
@@ -17,7 +17,8 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --sound off \
     --collisions off \
     --handicap on \
-    --wall-recovery on \
+    --wall-recovery off \
+    --start-random on \
     --ranking on \
     -screen-fullscreen 1 \
     -screen-width 1920 \


### PR DESCRIPTION
- dev.sh / parallel.sh: --wall-recovery を off に変更
- parallel.sh: --start-random on を追加
- README.md: 各スクリプトの設定一覧を更新