### PR TITLE
fix: sync .PHONY with renamed setup-vehicle target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # make file inspired by https://roborovsky-racers.github.io/RoborovskyNote/
 SHELL := /bin/bash
 
-.PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control  awsim-request-start awsim-request-reset autoware-driver-zenoh autoware-driver-zenoh-rosbag vehicle-setup-check \
+.PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control  awsim-request-start awsim-request-reset autoware-driver-zenoh autoware-driver-zenoh-rosbag setup-vehicle \
 	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-bash eval
 
 # Used by docker-compose.yml for build/eval artifact ownership.


### PR DESCRIPTION
## 概要

PR #237 のコミット [667094c](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/237/commits/667094c36ff23776d63c9d0c54138d51e4d7f50e) で Makefile のターゲット名が `vehicle-setup-check` → `setup-vehicle` にリネームされましたが、`.PHONY` 宣言が古い名前のまま取り残されていました。本PRで `.PHONY` を実ターゲット名に同期します。


## TEST
make setup-vehicleが実行できることを確認

<img width="1242" height="724" alt="image" src="https://github.com/user-attachments/assets/3e475cc0-7dc2-4ea0-ace5-65bcb9753b66" />