### PR TITLE
fix(setup): return docker's real exit code from the docker wrappers

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -284,11 +284,11 @@ docker_as_sudo_ok() {
 docker_run() {
     if docker_as_user_ok; then
         docker "$@"
-        return 0
+        return $?
     fi
     if cmd_exists sudo && cmd_exists docker; then
         sudo docker "$@"
-        return 0
+        return $?
     fi
     warn "${FAIL} docker not available"
     return 1
@@ -297,11 +297,11 @@ docker_run() {
 docker_run_no_prompt() {
     if docker_as_user_ok; then
         docker "$@"
-        return 0
+        return $?
     fi
     if docker_as_sudo_ok; then
         sudo -n docker "$@"
-        return 0
+        return $?
     fi
     return 1
 }
@@ -309,11 +309,11 @@ docker_run_no_prompt() {
 docker_compose_run() {
     if docker_as_user_ok; then
         docker compose "$@"
-        return 0
+        return $?
     fi
     if cmd_exists sudo && cmd_exists docker; then
         sudo docker compose "$@"
-        return 0
+        return $?
     fi
     warn "${FAIL} docker not available"
     return 1
@@ -322,11 +322,11 @@ docker_compose_run() {
 docker_compose_run_no_prompt() {
     if docker_as_user_ok; then
         docker compose "$@"
-        return 0
+        return $?
     fi
     if docker_as_sudo_ok; then
         sudo -n docker compose "$@"
-        return 0
+        return $?
     fi
     return 1
 }


### PR DESCRIPTION
## What

The four docker helpers in `setup.bash` run their command and then `return 0`
unconditionally, discarding docker's real exit status (8 sites):

```bash
docker_run_no_prompt() {
    if docker_as_user_ok; then
        docker "$@"
        return 0        # <-- docker's status is discarded
    fi
```

## Why it matters

**1. `doctor` reports images that do not exist.** On a clean host with only one
unrelated image present:

```
=== Repo ===
✅ image exists: aichallenge-2025-dev
✅ base image exists: ghcr.io/automotiveaichallenge/autoware-universe:humble-latest
```

`docker images` listed neither. `docker image inspect` failed and the wrapper
reported success anyway, so a new participant is told to skip
`./setup.bash pull image` and `./docker_build.sh dev` — the two slowest setup
steps — and then hits a confusing failure much later.

**2. The image-pull retry loop never retries.** In `pull_autoware_image()`:

```bash
for ((i = 1; i <= attempts; i++)); do
    if docker_run pull "$image"; then   # always true
        log "${OK} Pulled: ${image}"
        return 0
```

A failed pull is reported as `✅ Pulled:` and the five retry attempts are dead code.

**3. `doctor`'s compose-plugin check** (`docker_compose_run_no_prompt version`) has
the same problem.

## The change

`return 0` → `return $?` at the 8 sites, so the wrappers propagate docker's status.

All four helpers are only ever called in conditional contexts
(`if docker_run pull ...`, `... >/dev/null 2>&1 && _chk OK || _chk INFO`), so
returning a non-zero status is safe under the script's `set -e`.

## Verification

- `shellcheck setup.bash` — clean
- `shfmt -d -s -i=4 setup.bash` — no diff
- `bash -n setup.bash` — clean
- Re-ran `./setup.bash doctor` on a host with neither image present: now correctly
  reports `image missing` and points at the right next step.

Found while bringing up the 2026 environment. Happy to adjust anything.