### PR TITLE
feat: add max_acceleration param to simple_pure_pursuit

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/control/pure_pursuit.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/control/pure_pursuit.launch.xml
@@ -13,6 +13,7 @@
     <param name="lookahead_min_distance" value="3.5"/>
     <param name="speed_proportional_gain" value="1.0"/>
     <param name="steering_tire_angle_gain" value="$(var steering_tire_angle_gain_var)"/>
+    <param name="max_acceleration" value="3.0"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>
     <remap from="input/trajectory" to="/planning/scenario_planning/trajectory"/>

--- a/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/include/simple_pure_pursuit/simple_pure_pursuit.hpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/include/simple_pure_pursuit/simple_pure_pursuit.hpp
@@ -51,6 +51,7 @@ class SimplePurePursuit : public rclcpp::Node {
   const bool use_external_target_vel_;
   const double external_target_vel_;
   const double steering_tire_angle_gain_;
+  const double max_acceleration_;
 
 
  private:

--- a/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -23,7 +23,8 @@ SimplePurePursuit::SimplePurePursuit()
   speed_proportional_gain_(declare_parameter<float>("speed_proportional_gain", 1.0)),
   use_external_target_vel_(declare_parameter<bool>("use_external_target_vel", false)),
   external_target_vel_(declare_parameter<float>("external_target_vel", 0.0)),
-  steering_tire_angle_gain_(declare_parameter<float>("steering_tire_angle_gain", 1.0))
+  steering_tire_angle_gain_(declare_parameter<float>("steering_tire_angle_gain", 1.0)),
+  max_acceleration_(declare_parameter<float>("max_acceleration", 3.0))
 {
   pub_cmd_ = create_publisher<AckermannControlCommand>("output/control_cmd", 1);
   pub_raw_cmd_ = create_publisher<AckermannControlCommand>("output/raw_control_cmd", 1);
@@ -75,6 +76,7 @@ void SimplePurePursuit::onTimer()
   cmd.longitudinal.speed = target_longitudinal_vel;
   cmd.longitudinal.acceleration =
     speed_proportional_gain_ * (target_longitudinal_vel - current_longitudinal_vel);
+  cmd.longitudinal.acceleration = std::min<double>(cmd.longitudinal.acceleration, max_acceleration_);
 
   // calc lateral control
   //// calc lookahead distance


### PR DESCRIPTION
## 変更内容

- 現状のAWSIMでは加速度上限が厳しくなりました。結果として、simple_pure_pursuitだとスタート直後から常時「OVER」のペナルティが発生し続けます
- simple_pure_pursuitに`max_acceleration`パラメータを追加して、上限を超えないようにしました

<img width="1016" height="792" alt="image" src="https://github.com/user-attachments/assets/fb3adce9-fdb5-4119-a72a-8841528a0d9e" />

## 動作確認内容

- `control_method`を`pure_pursuit`にして走行が出来ること