### PR TITLE
feat: sync trajectory_generator's raceline to mpc's reference

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -127,9 +127,13 @@
     <group>
       <push-ros-namespace namespace="scenario_planning"/>
 
-      <!-- Customizable -->
+      <!-- get mpc config and ref path inside -->
+      <arg name="mpc_config_file" default="$(eval &quot;'config.yaml' if '$(var track)' == 'citycircuit' else 'config_' + '$(var track)' + '.yaml'&quot;)"/>
+      <arg name="mpc_ref_csv" default="$(command python3 -c 'import yaml; print(yaml.safe_load(open(&quot;$(find-pkg-share multi_purpose_mpc_ros)/config/$(var mpc_config_file)&quot;))[&quot;reference_path&quot;][&quot;csv_path&quot;])')"/>
+      
+      <!-- link the trajectory generator to use mpc reference line -->
       <node pkg="simple_trajectory_generator" exec="simple_trajectory_generator_node" name="simple_trajectory_generator" output="screen">
-            <param name="csv_path" value="$(find-pkg-share simple_trajectory_generator)/data/$(var track_subdir)raceline_awsim_30km_from_garage.csv"/>
+            <param name="csv_path" value="$(find-pkg-share multi_purpose_mpc_ros)/$(var mpc_ref_csv)"/>
             <param name="z" value="6.5"/>
       </node>
       

--- a/aichallenge/workspace/src/aichallenge_submit/simple_trajectory_generator/src/simple_trajectory_generator.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_trajectory_generator/src/simple_trajectory_generator.cpp
@@ -83,22 +83,33 @@ private:
         values.push_back(std::stod(token));
       }
       
-      if (values.size() != 8) {
-        RCLCPP_WARN(get_logger(), "Invalid CSV line format, expected 8 values");
+      // MPC has 7, while default raceline has 8
+      if (values.size() != 7) {
+        RCLCPP_WARN(get_logger(), "Invalid CSV line format, expected 7 values");
         continue;
       }
       
+      // Note: in mpc
+      // x: values[1]
+      // y: values[2]
+      // psi: values[3]
+      // x_quat, y_quat = 0 (no pitch and roll)
+      // z_quat = sin(psi/2)
+      // w_quat = cos(psi/2)
+      // v = values[5]
+
       TrajectoryPoint point;
-      point.pose.position.x = values[0];
-      point.pose.position.y = values[1];
+      point.pose.position.x = values[1];
+      point.pose.position.y = values[2];
       point.pose.position.z = z_;
 
-      point.pose.orientation.x = values[3];
-      point.pose.orientation.y = values[4];
-      point.pose.orientation.z = values[5];
-      point.pose.orientation.w = values[6];
-      
-      point.longitudinal_velocity_mps = values[7];
+      point.pose.orientation.x = 0.0;
+      point.pose.orientation.y = 0.0;
+      const auto &psi = values[3];
+      point.pose.orientation.z = std::sin(psi/2);
+      point.pose.orientation.w = std::cos(psi/2);
+
+      point.longitudinal_velocity_mps = values[5];
       
       point.lateral_velocity_mps = 0.0;
       point.acceleration_mps2 = 0.0;


### PR DESCRIPTION
### Description
Currently, MPC's reference and the Reference inside the rviz (using `simple_trajectory_generator)is` different due to different style of csv and location.
It causes inconsistency in the reference change. 

This PR let the `simple_trajectory_generator` to point to MPC's reference path and handle it.

1) change launch file to point to mpc config, and its ref path 
2) change the value handle for each row in the ref