### PR TITLE
refactor: parameterize devN/gateN make targets with pattern rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,16 @@ LOG_DIR := /output/$(TIMESTAMP)
 
 # make simulator-<mode>: <mode> は simulator_scripts/*.sh のファイル名
 SIM_MODES := $(notdir $(basename $(wildcard aichallenge/simulator_scripts/*.sh)))
-# dev<N>（車両数）/ gate<N>（テスト番号）は run_simulator.bash が展開するエイリアス
-SIM_MODES += dev2 dev3 dev4 gate1 gate2 gate3
+# dev<N>（車両数、2..4）は run_simulator.bash が展開するエイリアス
+DEV_NS := 2 3 4
+SIM_MODES += $(addprefix dev,$(DEV_NS))
 .PHONY: $(addprefix simulator-,$(SIM_MODES))
 $(addprefix simulator-,$(SIM_MODES)): simulator-%:
 	@$(MAKE) simulator SIM_MODE=$*
+
+# gate<N>（テスト番号、任意）も run_simulator.bash が展開するエイリアス
+simulator-gate%:
+	@$(MAKE) simulator SIM_MODE=gate$*
 
 # autowareのbuildのみ
 autoware-build:
@@ -72,17 +77,11 @@ zenoh:
 
 dev: SIM_MODE := dev
 dev: simulator autoware-simulator
-	@echo "Start dev simulation (AWSIM + Autoware)"
-	@echo "To stop: make down  (docker compose down --remove-orphans)"
 
-dev2: SIM_MODE := dev2
-dev3: SIM_MODE := dev3
-dev4: SIM_MODE := dev4
-dev2 dev3 dev4: simulator
-	@N=$(@:dev%=%); \
-	echo "Start $$N-vehicle dev (autoware on ROS_DOMAIN_ID 1..$$N via docker compose -p)"; \
-	for p in $$(seq 1 $$N); do LOG_DIR=$(LOG_DIR) ROS_DOMAIN_ID=$$p docker compose -p $$p up -d autoware; done; \
-	echo "To Stop: make down"
+# dev<N>: N台並列（autoware を compose -p 1..N / ROS_DOMAIN_ID=1..N で起動）
+$(addprefix dev,$(DEV_NS)): dev%:
+	@$(MAKE) simulator SIM_MODE=$@ LOG_DIR=$(LOG_DIR)
+	@for p in $$(seq 1 $*); do LOG_DIR=$(LOG_DIR) ROS_DOMAIN_ID=$$p docker compose -p $$p up -d autoware; done
 
 # e2e は練習兼提出参考モード（e2e.sh）。e2e-final.sh は make simulator-e2e-final。
 e2e: SIM_MODE := e2e
@@ -90,12 +89,10 @@ e2e: simulator autoware-simulator
 	@echo "Start e2e simulation (AWSIM + Autoware)"
 	@echo "To stop: make down  (docker compose down --remove-orphans)"
 
-gate1: SIM_MODE := gate1
-gate2: SIM_MODE := gate2
-gate3: SIM_MODE := gate3
-gate1 gate2 gate3: simulator autoware-simulator
-	@echo "Start safety gate simulation (AWSIM + Autoware)"
-	@echo "To stop: make down  (docker compose down --remove-orphans)"
+# gate<N>: 任意のテスト番号を受け付ける（例: make gate7）
+gate%:
+	@$(MAKE) simulator SIM_MODE=$@ LOG_DIR=$(LOG_DIR)
+	@$(MAKE) autoware-simulator LOG_DIR=$(LOG_DIR)
 
 eval:
 	@echo "Start evaluation simulation (AWSIM + Autoware)"


### PR DESCRIPTION
## 概要

Makefile の `dev2/dev3/dev4` と `gate1/gate2/gate3` の列挙を、パターンルールで一般化しました。

- **dev\<N\>**: 車両数は 2..4 に限定したいので `DEV_NS := 2 3 4` の列挙を維持しつつ、既存の `simulator-%` と同じ「静的パターンルール + 再帰 make」イディオムに集約。stem (`$*`) がそのまま車両数になるため、`$(@:dev%=%)` の変換と per-target の `SIM_MODE :=` 3行が不要に
- **gate\<N\>**: `gate%` の真のパターンルールに変更し、任意のテスト番号を受け付ける（例: `make gate7`）。`run_simulator.bash` 側は元々 `^(dev|gate)([0-9]+)$` で任意番号を展開するので、Makefile の列挙だけがボトルネックだった
- **simulator-gate\<N\>**: AWSIM 単体起動も任意番号で使えるよう `simulator-gate%` パターンを追加（`SIM_MODES` から gate1..3 の列挙を削除）

## 実装メモ

- 前提ターゲット方式（target-specific な `SIM_MODE` の継承）はパターンルールでは stem を変数値に埋め込めず成立しないため、レシピ内で `$(MAKE) simulator SIM_MODE=$@` を呼ぶ方式に変更
- 再帰 make は `TIMESTAMP` を再評価してログ出力先がズレるため、`LOG_DIR=$(LOG_DIR)` を明示的に引き継いで simulator / autoware が同一ディレクトリに揃うようにした
- 「Start AWSIM (SIM_MODE=…)」「Start Autoware for AWSIM」「Log dir: …」は `simulator` / `autoware-simulator` 側が出力するため、重複する echo 行を削除

## 動作確認

`make -n` のドライランで以下を確認:

- `dev` / `dev3` / `e2e`: 従来と同じコマンド列に展開（LOG_DIR も simulator / autoware 間で一致）
- `gate2` / `gate7` / `simulator-gate9` / `simulator-dev2`: 期待どおり展開
- `dev5`: 「ルールがありません」で正しく拒否

## 補足

パターンルールは `.PHONY` 指定できないため、リポジトリ直下に `gate1` 等の名前のファイルが偶然存在すると「up to date」でスキップされます（実運用上は問題にならない想定）。