### PR TITLE
feat: allow driver launch arguments to be set from the environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ TEAM_NAME="ABC"
 ROS_DOMAIN_ID=1
 # Must be an absolute path because colcon --symlink-install can contain absolute symlinks.
 RACING_KART_INTERFACE_DIR=/home/tier4/racing_kart_interface
+# Extra `ros2 launch` arguments for the driver, e.g. DRIVER_LAUNCH_ARGS=max_accel_ratio:=0.35
+DRIVER_LAUNCH_ARGS=
 # Host identity, auto-filled by `./setup.bash env` / `make` (id -u, id -g, dialout GID for /dev/vcu,/dev/gnss, input GID for /dev/input/event*).
 HOST_UID=1000
 HOST_GID=1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,10 +146,6 @@ services:
     # fixes log ownership back to HOST_UID:HOST_GID.
     user: "root"
     entrypoint: []
-    # DRIVER_LAUNCH_ARGS is forwarded verbatim to `ros2 launch` (run_driver.bash ->
-    # entrypoint.sh -> utils/run.bash), so driver params can be swept on site without
-    # rebuilding the image, e.g. DRIVER_LAUNCH_ARGS="max_accel_ratio:=0.35" make driver.
-    # Left unquoted on purpose so that multiple arguments split into separate words.
     command: ["bash", "-lc", 'exec /vehicle/run_driver.bash vehicle "${ROS_DOMAIN_ID:-1}" "${LOG_DIR:-}" ${DRIVER_LAUNCH_ARGS:-}']
 
 #### remote visualization services ####

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,11 @@ services:
     # fixes log ownership back to HOST_UID:HOST_GID.
     user: "root"
     entrypoint: []
-    command: ["bash", "-lc", "exec /vehicle/run_driver.bash vehicle ${ROS_DOMAIN_ID:-1} ${LOG_DIR:-}"]
+    # DRIVER_LAUNCH_ARGS is forwarded verbatim to `ros2 launch` (run_driver.bash ->
+    # entrypoint.sh -> utils/run.bash), so driver params can be swept on site without
+    # rebuilding the image, e.g. DRIVER_LAUNCH_ARGS="max_accel_ratio:=0.35" make driver.
+    # Left unquoted on purpose so that multiple arguments split into separate words.
+    command: ["bash", "-lc", 'exec /vehicle/run_driver.bash vehicle "${ROS_DOMAIN_ID:-1}" "${LOG_DIR:-}" ${DRIVER_LAUNCH_ARGS:-}']
 
 #### remote visualization services ####
   rviz2:

--- a/vehicle/README.md
+++ b/vehicle/README.md
@@ -59,6 +59,26 @@ make zenoh
 make autoware-driver-zenoh
 ```
 
+### ドライバーのパラメータを現地で振る
+
+`DRIVER_LAUNCH_ARGS` に書いた文字列は、そのまま driver の `ros2 launch` へ引数として渡ります。
+イメージを焼き直さずに値を変えられるので、現地での調整はこれを使ってください。
+
+```bash
+# 例: スロットル上限を 0.35 にして起動
+DRIVER_LAUNCH_ARGS="max_accel_ratio:=0.35" make autoware-driver-zenoh-rosbag
+```
+
+基準値は `.env` の `DRIVER_LAUNCH_ARGS` に書いておけます（コマンドラインで渡した値が優先されます）。
+
+**値が実際に入ったかは毎回確認してください。** 引数名を間違えても ROS はエラーも警告も出さず、黙って無視します。
+
+```bash
+CMD="ros2 param get /racing_kart_driver max_accel_ratio" docker compose run --rm --no-deps autoware-command
+```
+
+渡せるのは racing_kart_interface 側の launch が `<arg>` として宣言しているパラメータだけです。
+
 ### 可視化 / 記録
 
 ```bash

--- a/vehicle/README.md
+++ b/vehicle/README.md
@@ -59,26 +59,6 @@ make zenoh
 make autoware-driver-zenoh
 ```
 
-### ドライバーのパラメータを現地で振る
-
-`DRIVER_LAUNCH_ARGS` に書いた文字列は、そのまま driver の `ros2 launch` へ引数として渡ります。
-イメージを焼き直さずに値を変えられるので、現地での調整はこれを使ってください。
-
-```bash
-# 例: スロットル上限を 0.35 にして起動
-DRIVER_LAUNCH_ARGS="max_accel_ratio:=0.35" make autoware-driver-zenoh-rosbag
-```
-
-基準値は `.env` の `DRIVER_LAUNCH_ARGS` に書いておけます（コマンドラインで渡した値が優先されます）。
-
-**値が実際に入ったかは毎回確認してください。** 引数名を間違えても ROS はエラーも警告も出さず、黙って無視します。
-
-```bash
-CMD="ros2 param get /racing_kart_driver max_accel_ratio" docker compose run --rm --no-deps autoware-command
-```
-
-渡せるのは racing_kart_interface 側の launch が `<arg>` として宣言しているパラメータだけです。
-
 ### 可視化 / 記録
 
 ```bash


### PR DESCRIPTION
## Description
racing_kart_interfaceのlaunch引数をmakeコマンドから渡せるように修正しました。
throttle調整が完了した場合は引数を渡せるようになっていなくてもいいが、あえて塞ぐ理由もないので取り込む。

## Test
実車動作確認済み
