### PR TITLE
feat(joy): route joy to the operator topic

### DIFF
--- a/vehicle/setup_check.md
+++ b/vehicle/setup_check.md
@@ -225,7 +225,7 @@ docker compose -f ../docker-compose.yml exec -T driver bash -lc \
 
 | コンテナ | トピック |
 | --- | --- |
-| `driver` | `/racing_kart/vcu/status`, `/racing_kart/steer/status`, `/racing_kart/brake/status`, `/racing_kart/joy` |
+| `driver` | `/racing_kart/vcu/status`, `/racing_kart/steer/status`, `/racing_kart/brake/status`, `/racing_kart/operator/joy` |
 | `driver` | `/racing_kart/vcu/command`, `/racing_kart/steer/command`, `/racing_kart/brake/command` |
 | `autoware` | `/vehicle/status/velocity_status`, `/vehicle/status/steering_status`, `/vehicle/status/gear_status`, `/vehicle/status/actuation_status` |
 | `autoware` | `/control/command/control_cmd`, `/control/command/actuation_cmd` |

--- a/vehicle/setup_check.sh
+++ b/vehicle/setup_check.sh
@@ -667,7 +667,7 @@ check_runtime_ros_topics() {
     check_ros_topic_once "driver" "/racing_kart/vcu/status" "VCU status"
     check_ros_topic_once "driver" "/racing_kart/steer/status" "Steer status"
     check_ros_topic_once "driver" "/racing_kart/brake/status" "Brake status"
-    check_ros_topic_once "driver" "/racing_kart/joy" "Joy input"
+    check_ros_topic_once "driver" "/racing_kart/operator/joy" "Joy input"
 
     log "${INFO} Racing kart final command topics"
     check_ros_topic_once "driver" "/racing_kart/vcu/command" "VCU command"

--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -65,6 +65,7 @@
         ],
         subscribers: [
           "/racing_kart/joy",
+          "/racing_kart/operator/joy",
           "/initialpose"
         ],
         service_servers: [],


### PR DESCRIPTION
## 概要

車両側の `racing_kart_driver` が joy を `/racing_kart/operator/joy` で購読するようになりました（`racing_kart_interface` #3 `feat/dual-joy-input`）。車両側ブリッジの許可リストと setup_check の確認トピックを追随させます。

対になる変更: `aichallenge-racingkart-remote` #1（遠隔側 manager の配信先）。

## 変更点

3ファイル、トピック名の追加とリネームだけです。

| 対象 | 変更 |
| --- | --- |
| `vehicle/zenoh.json5` | subscribers に `/racing_kart/operator/joy` を追加（`/racing_kart/joy` は残す） |
| `vehicle/setup_check.sh` | Joy input の確認トピックを追随 |
| `vehicle/setup_check.md` | 確認トピック表を追随 |

`remote/`（参加者向けの遠隔スタック）は触っていません。`/racing_kart/joy` を許可リストに残しているので、参加者側の経路は現状のまま影響を受けません。参加者joy（driver 側の `/racing_kart/user/joy`）の経路は今回の対象外です。

## テスト

```
$ bash -n vehicle/setup_check.sh          # syntax OK
$ pre-commit run --files vehicle/setup_check.sh vehicle/vehicle_ports.sh
  shellcheck Passed / shfmt Passed
```

`vehicle/zenoh.json5` はコメントと末尾カンマを除去したうえで JSON としてパースできることを確認済み。実機確認は未実施です。

## 別件で未解決の前提（このPRの範囲外）

遠隔側の `zenoh-user.json5.template` は「車両側のブリッジが `-n /<VEHICLE_ID>` で名前空間を剥がす」前提ですが、`vehicle/run_zenoh.bash` は `dev` / `experiment` / `main` のいずれでも `-n` を渡していません。この状態では遠隔PCの `/A2/...` は車両に届きません（joy に限らず全トピック）。「ゼノブリッジの設定 / 車両ごとのトピックルーティング確立」の宿題そのものなので、このPRでは触っていません。
