### PR TITLE
feat(joy)!: split the joy topics into sd and so

### DIFF
--- a/aichallenge/simulator_scripts/dev.sh
+++ b/aichallenge/simulator_scripts/dev.sh
@@ -20,6 +20,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap off \
     --wall-recovery off \
+    --overtaking-lane off \
     --ranking off \
     --camera off \
     --lidar off

--- a/aichallenge/simulator_scripts/e2e-final.sh
+++ b/aichallenge/simulator_scripts/e2e-final.sh
@@ -18,6 +18,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap on \
     --wall-recovery off \
+    --overtaking-lane off \
     --start-random off \
     --ranking on \
     --camera cpu \

--- a/aichallenge/simulator_scripts/s2r-final.sh
+++ b/aichallenge/simulator_scripts/s2r-final.sh
@@ -18,6 +18,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap on \
     --wall-recovery off \
+    --overtaking-lane on \
     --start-random off \
     --ranking on \
     --camera off \

--- a/remote/gui_tools.py
+++ b/remote/gui_tools.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import queue
+import signal
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -322,7 +324,7 @@ COMMANDS: List[CommandSpec] = [
     ),
     CommandSpec(
         label="Restart Joy",
-        command="bash -lc \"pkill -f 'ros2 run joy joy_node' || true; ./joy.bash\"",
+        command="./joy.bash",
         log_key="joy",
         stop_before=True,
         note="joy ノードを再起動します。",
@@ -510,6 +512,12 @@ class RemoteGui:
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
+                # 起動するのは bash -> スクリプト -> ros2 run -> 実体 の多段で、
+                # ros2 run は joy_node を別プロセスとして起こす。専用のプロセス
+                # グループに入れておかないと、停止時に親だけが死んで実体が孤児
+                # として残り (親が systemd に引き取られる)、GUI から止められなく
+                # なる。同じ理由で scripts/run_remote.bash もグループで畳んでいる。
+                start_new_session=True,
             )
         except FileNotFoundError:
             messagebox.showerror("Command error", f"bash が見つかりませんでした。")
@@ -544,12 +552,24 @@ class RemoteGui:
         if not process:
             return
         if process.poll() is None:
-            process.terminate()
+            self._signal_process_group(process, signal.SIGTERM)
             try:
                 process.wait(timeout=3)
             except subprocess.TimeoutExpired:
-                process.kill()
+                self._signal_process_group(process, signal.SIGKILL)
         self._append_log(log_key, "[process terminated]\n")
+
+    @staticmethod
+    def _signal_process_group(process: subprocess.Popen[str], sig: int) -> None:
+        """子孫ごと畳む。start_new_session=True で作ったグループに送る。"""
+        try:
+            os.killpg(os.getpgid(process.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            # グループが既に消えている場合などは、直接の子だけに送って諦める。
+            if sig == signal.SIGKILL:
+                process.kill()
+            else:
+                process.terminate()
 
     def _process_running(self, log_key: str) -> bool:
         proc = self.processes.get(log_key)

--- a/remote/joy.bash
+++ b/remote/joy.bash
@@ -1,2 +1,2 @@
 #!/bin/bash
-ros2 run joy joy_node --ros-args -r __ns:=/racing_kart
+ros2 run joy joy_node --ros-args -r __ns:=/racing_kart/so

--- a/remote/zenoh-user.json5
+++ b/remote/zenoh-user.json5
@@ -55,7 +55,7 @@
       allow: {
         publishers: [
           "/initialpose",
-          "/racing_kart/joy"
+          "/racing_kart/so/joy"
         ],
         subscribers: [
           "/control/command/control_cmd",
@@ -102,7 +102,7 @@
       ////                   to create a bigger batch of messages. This usually has a positive impact on latency for the topic
       ////                   but a negative impact on the general throughput, as more overhead is used for those topics.
       pub_priorities: [
-        "/racing_kart/joy=1:express",
+        "/racing_kart/so/joy=1:express",
         "/initialpose=1:express",
       ],
 

--- a/vehicle/setup_check.md
+++ b/vehicle/setup_check.md
@@ -225,7 +225,7 @@ docker compose -f ../docker-compose.yml exec -T driver bash -lc \
 
 | コンテナ | トピック |
 | --- | --- |
-| `driver` | `/racing_kart/vcu/status`, `/racing_kart/steer/status`, `/racing_kart/brake/status`, `/racing_kart/joy` |
+| `driver` | `/racing_kart/vcu/status`, `/racing_kart/steer/status`, `/racing_kart/brake/status`, `/racing_kart/sd/joy` |
 | `driver` | `/racing_kart/vcu/command`, `/racing_kart/steer/command`, `/racing_kart/brake/command` |
 | `autoware` | `/vehicle/status/velocity_status`, `/vehicle/status/steering_status`, `/vehicle/status/gear_status`, `/vehicle/status/actuation_status` |
 | `autoware` | `/control/command/control_cmd`, `/control/command/actuation_cmd` |

--- a/vehicle/setup_check.sh
+++ b/vehicle/setup_check.sh
@@ -667,7 +667,7 @@ check_runtime_ros_topics() {
     check_ros_topic_once "driver" "/racing_kart/vcu/status" "VCU status"
     check_ros_topic_once "driver" "/racing_kart/steer/status" "Steer status"
     check_ros_topic_once "driver" "/racing_kart/brake/status" "Brake status"
-    check_ros_topic_once "driver" "/racing_kart/joy" "Joy input"
+    check_ros_topic_once "driver" "/racing_kart/sd/joy" "Joy input"
 
     log "${INFO} Racing kart final command topics"
     check_ros_topic_once "driver" "/racing_kart/vcu/command" "VCU command"

--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -64,7 +64,8 @@
           "/vehicle/status/velocity_status"
         ],
         subscribers: [
-          "/racing_kart/joy",
+          "/racing_kart/sd/joy",
+          "/racing_kart/so/joy",
           "/initialpose"
         ],
         service_servers: [],


### PR DESCRIPTION
## 概要

`racing_kart_interface` [#8 (feat: arbitrate the safety driver joy and the participant joy)](https://github.com/AutomotiveAIChallenge/racing_kart_interface/pull/8) にアラインする経路側の変更です。

#8 で joy が送信元ごとに分かれ、`racing_kart_driver_node` が `/racing_kart/sd/joy`（運営）と `/racing_kart/so/joy`（参加者）を購読して内部の `JoyArbiter` で調停します。**`/racing_kart/joy` は廃止**されるため、参加者PCと車両側の経路名を追随させます。

#8 の `docs/joy-arbiter-design.md`「変更ファイル > 別リポジトリ (`aichallenge-racingkart`)」の対応表どおりです。

## 変更点

| 対象 | 変更 | #8 の対応表 |
| --- | --- | --- |
| `remote/joy.bash`（参加者） | `__ns:=/racing_kart/so` | ✔ |
| `remote/zenoh-user.json5`（参加者） | `allow.publishers` と `pub_priorities` を `/racing_kart/so/joy` へ | ✔ |
| `vehicle/zenoh.json5`（ECU） | `allow.subscribers` を `/racing_kart/sd/joy` + `/racing_kart/so/joy` の2本へ | ✔ |
| `vehicle/setup_check.sh` / `.md` | Joy input の確認先を `/racing_kart/sd/joy` へ | （表には無いが `/racing_kart/joy` 廃止の帰結） |
| `remote/gui_tools.py`（参加者） | Stop / Restart をプロセスグループごと畳むよう修正 | （表には無い。実機確認中に判明） |

運営側（対応表の `zenoh-admin.json5` / `admin_operator.py`）は遠隔操作スタックの分離後は `aichallenge-racingkart-remote` にあるため、そちらの [#2](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart-remote/pull/2) で対応しています。

`setup_check` の確認先を `sd` にしたのは、#8 で車載 `joy_node` が `racing_kart_manager.launch.xml` の `namespace="/racing_kart/sd"` へ移るためです。運営joyが無ければ誰も操作できない（#8 の `require_sd_joy=true`）ので、必須チェックの対象としても `sd` が正しい先になります。

## `remote/gui_tools.py` の修正

実機確認中に、GUI の Stop / Restart で `joy_node` が止まらない問題を踏んだので併せて直しました。

GUI は `bash → joy.bash → ros2 run → joy_node` の多段でプロセスを起こしますが、停止処理が直接の子（bash）にしか SIGTERM を送っていなかったため、実体の `joy_node` が孤児として残ります（親が `systemd --user` に移り GUI から止められなくなる）。残骸が `/dev/input/event*` を掴んだままなので、Restart しても新しい `joy_node` が入力を読めず publish が止まります。

`start_new_session=True` でプロセスグループを作り、停止時は `killpg` でグループごと畳むようにしました。`aichallenge-racingkart-remote` の `scripts/run_remote.bash` が同じ理由でグループを畳んでいるのに揃えています。`Restart Joy` の `pkill -f 'ros2 run joy joy_node'` も外しました（実体は `/opt/ros/humble/lib/joy/joy_node` でこのパターンにマッチせず残骸を落とせておらず、グループで畳めば不要）。

remote-so-1 で Stop / Restart が効くことを確認済みです。

## 依存関係

**#8 のマージが前提です。** 先にこちらだけ入れると、`/racing_kart/joy` を購読している現行 driver に joy が届かなくなります。#8 と同時に投入してください。

逆に #8 だけを入れた場合も、参加者PCは `/racing_kart/joy` を publish し続けるため joy が届きません。#8 の設計にあるとおり「設定を更新し忘れた参加者PCは走れないので止まる」挙動になります。

## テスト

```
$ bash -n vehicle/setup_check.sh          # syntax OK
$ pre-commit run --files remote/joy.bash vehicle/setup_check.sh vehicle/vehicle_ports.sh
  shellcheck Passed / shfmt Passed
```

json5 の2ファイルはコメントと末尾カンマを除去したうえで JSON としてパースできることを確認済み。実機確認は未実施です。


遠隔SDが遠隔SOの操作をオーバーライドできることを確認

