### PR TITLE
feat: simulator_scripts に --overtaking-lane フラグを追加

### DIFF
--- a/aichallenge/simulator_scripts/dev.sh
+++ b/aichallenge/simulator_scripts/dev.sh
@@ -20,6 +20,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap off \
     --wall-recovery off \
+    --overtaking-lane off \
     --ranking off \
     --camera off \
     --lidar off

--- a/aichallenge/simulator_scripts/e2e-final.sh
+++ b/aichallenge/simulator_scripts/e2e-final.sh
@@ -18,6 +18,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap on \
     --wall-recovery off \
+    --overtaking-lane off \
     --start-random off \
     --ranking on \
     --camera cpu \

--- a/aichallenge/simulator_scripts/s2r-final.sh
+++ b/aichallenge/simulator_scripts/s2r-final.sh
@@ -18,6 +18,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap on \
     --wall-recovery off \
+    --overtaking-lane on \
     --start-random off \
     --ranking on \
     --camera off \


### PR DESCRIPTION
## 概要
AWSIM の追い越しレーン(BLOCK ペナルティ)フラグ `--overtaking-lane` を simulator_scripts に明示追加します。

| スクリプト | 設定 |
|---|---|
| `s2r-final.sh` | **on** |
| `dev.sh` (make dev) | off |
| `e2e-final.sh` | off |

## 注意
- **E2E(決勝含む)では適用しません**(`e2e-final.sh` は明示的に off)。追い越しレーンペナルティは S2R 決勝のみで有効です。
- `off` は AWSIM のデフォルト値と同じですが、決勝設定との差分を明示するために記載しています。
- AWSIM 側の対応:(hot 状態のオレンジ脈動可視化 + 起動UIトグル)。