### PR TITLE
fix: so the $USER can run `docker` without `sudo`

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -417,6 +417,7 @@ ensure_docker_group() {
     log "${INFO} Adding ${USER-} to docker group"
     sudo_refresh
     sudo usermod -aG docker "${USER-}"
+    sudo newgrp docker
     warn "${WARN} Docker group takes effect after re-login."
     if [ "${SETUP_ASSUME_YES}" = "1" ]; then
         warn "${INFO} Non-interactive mode: continuing, but docker commands may fail until re-login."

--- a/setup.bash
+++ b/setup.bash
@@ -417,7 +417,7 @@ ensure_docker_group() {
     log "${INFO} Adding ${USER-} to docker group"
     sudo_refresh
     sudo usermod -aG docker "${USER-}"
-    sudo newgrp docker
+    newgrp docker
     warn "${WARN} Docker group takes effect after re-login."
     if [ "${SETUP_ASSUME_YES}" = "1" ]; then
         warn "${INFO} Non-interactive mode: continuing, but docker commands may fail until re-login."


### PR DESCRIPTION
## Description

This PR fixes an issue that the $USER cannot run `docker` command even after the setting up by the following command:

```bash
$ curl -fsSL "https://raw.githubusercontent.com/AutomotiveAIChallenge/aichallenge-racingkart/main/setup.bash" | bash
```

- `newgrp docker` is applied only for current shell session
- Please do `shutdown -r now` for restart to apply the change for entire user environment（logging out does not apply as expected）

(日本語でも失礼します :pray:)

- `newgrp docker` はカレントターミナルにしか反映されません
- 正式に反映させるためにはマシンを再起動してください（logoutでは反映されないです）

## Note to Reviewers

Even with this PR fix, perhaps the user needs to restart the machine for applying the configuration.

## How was this PR tested

- I ran the following command with including this PR fix.
```bash
$ curl -fsSL "https://raw.githubusercontent.com/AutomotiveAIChallenge/aichallenge-racingkart/main/setup.bash" | bash
```
- Then ran the following command without `sudo`, which failed before this PR fix due to permission error:
```
$ docker images
```

## Misc

Please let me know for example if necessary tests are missing and so on :+1: 

I'm very happy to follow all requested fixes, tests, ... etc :smile: 

Thank you so much for your review!