### PR TITLE
feat: add evaluation-environment entrypoints and unify AWSIM launch args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 .PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control  awsim-request-start awsim-request-reset autoware-driver-zenoh autoware-driver-zenoh-rosbag setup-vehicle \
-	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-attach autoware-bash eval e2e vehicle-tui
+	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-attach autoware-bash eval eval-gate e2e vehicle-tui
 
 # Used by docker-compose.yml for build/eval artifact ownership.
 HOST_UID ?= $(shell id -u)
@@ -99,6 +99,10 @@ eval:
 	docker compose up -d autoware-simulator-evaluation
 	$(MAKE) awsim-request-start
 	@echo "To stop: make down  (docker compose down --remove-orphans)"
+
+# Safety gate (all scenarios) through the full evaluation flow.
+eval-gate:
+	@$(MAKE) eval SIM_MODE=gate
 
 # remote operation (docker compose up -d rviz2)
 rviz2:

--- a/aichallenge/README.md
+++ b/aichallenge/README.md
@@ -21,7 +21,7 @@
 ## `aichallenge/` 配下の主要ファイル（設計思想）
 
 - `aichallenge/run_evaluation.bash`: 評価オーケストレータ。起動→待機→初期化→収集→後処理までを1本で管理
-- `aichallenge/run_safety_gate.bash` / `aichallenge/run_parallel.bash`: 評価環境（aichallenge-aws）の入口。ROS overlay の source と `SIM_MODE` を自分で決めてから起動する自己完結スクリプト（契約: `docs/interface/evaluation-interface.md` §6）
+- `aichallenge/run_evaluation.bash` / `aichallenge/run_safety_gate.bash` / `aichallenge/run_parallel.bash`: 評価環境（aichallenge-aws）の入口でもある。ROS overlay の source と `SIM_MODE` を自分で決める自己完結スクリプト（契約: `docs/interface/evaluation-interface.md` §6）
 - `aichallenge/build_autoware.bash`: overlay(`aichallenge/workspace/`) のビルド。必要なら `clean` で `build/install/log` を削除
 - `aichallenge/run_simulator.bash`: AWSIM の起動。`SIM_MODE` をファイル名として `simulator_scripts/<mode>.sh` に委譲（起動引数の正本は各スクリプト側）
 - `aichallenge/run_autoware.bash`: Autoware の起動。`awsim/vehicle/rosbag` などモード別に launch 引数を整理

--- a/aichallenge/README.md
+++ b/aichallenge/README.md
@@ -21,6 +21,7 @@
 ## `aichallenge/` 配下の主要ファイル（設計思想）
 
 - `aichallenge/run_evaluation.bash`: 評価オーケストレータ。起動→待機→初期化→収集→後処理までを1本で管理
+- `aichallenge/run_safety_gate.bash` / `aichallenge/run_parallel.bash`: 評価環境（aichallenge-aws）の入口。ROS overlay の source と `SIM_MODE` を自分で決めてから起動する自己完結スクリプト（契約: `docs/interface/evaluation-interface.md` §6）
 - `aichallenge/build_autoware.bash`: overlay(`aichallenge/workspace/`) のビルド。必要なら `clean` で `build/install/log` を削除
 - `aichallenge/run_simulator.bash`: AWSIM の起動。`SIM_MODE` をファイル名として `simulator_scripts/<mode>.sh` に委譲（起動引数の正本は各スクリプト側）
 - `aichallenge/run_autoware.bash`: Autoware の起動。`awsim/vehicle/rosbag` などモード別に launch 引数を整理

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -17,7 +17,7 @@ exec > >(tee -a "${log_file}") 2>&1
 
 sim_mode="${SIM_MODE:-eval}"
 
-ros2 launch aichallenge_system_launch evaluation.launch.xml \
+exec ros2 launch aichallenge_system_launch evaluation.launch.xml \
     "domain_id:=${domain_id}" \
     "sim_mode:=${sim_mode}" \
     "log_dir:=${out_dir}" \

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+# Single-vehicle evaluation. Also an evaluation-environment entrypoint (s2r_1_practice_solo);
+# it sources its own ROS overlays because that image has no docker-entrypoint.sh
+# (docs/interface/evaluation-interface.md §6). Sourcing again locally is harmless.
+
+# shellcheck disable=SC1091
+source /aichallenge/workspace/install/setup.bash
+# The evaluation image builds the submission as an overlay under /aichallenge/d1 (aichallenge-aws makefile/Dockerfile);
+# the local eval image builds it into /aichallenge/workspace, so the overlay is optional.
+if [ -f /aichallenge/d1/workspace/install/setup.bash ]; then
+    # shellcheck disable=SC1091
+    source /aichallenge/d1/workspace/install/setup.bash
+fi
 
 domain_id="${ROS_DOMAIN_ID:-1}"
 ts="$(date +%Y%m%d-%H%M%S)"

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
-# Single-vehicle evaluation. Also an evaluation-environment entrypoint (s2r_1_practice_solo);
-# it sources its own ROS overlays because that image has no docker-entrypoint.sh
-# (docs/interface/evaluation-interface.md §6). Sourcing again locally is harmless.
+# Single-vehicle evaluation; also the evaluation-environment entrypoint for s2r_1_practice_solo,
+# where no docker-entrypoint.sh has sourced ROS (docs/interface/evaluation-interface.md §6).
 
-# shellcheck disable=SC1091
-source /aichallenge/workspace/install/setup.bash
-# The evaluation image builds the submission as an overlay under /aichallenge/d1 (aichallenge-aws makefile/Dockerfile);
-# the local eval image builds it into /aichallenge/workspace, so the overlay is optional.
+# The evaluation image builds the submission as the d1 overlay, whose setup.bash chains the base workspace.
 if [ -f /aichallenge/d1/workspace/install/setup.bash ]; then
     # shellcheck disable=SC1091
     source /aichallenge/d1/workspace/install/setup.bash
+else
+    # shellcheck disable=SC1091
+    source /aichallenge/workspace/install/setup.bash
 fi
 
 domain_id="${ROS_DOMAIN_ID:-1}"

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -25,4 +25,5 @@ exec ros2 launch aichallenge_system_launch evaluation.launch.xml \
     "rosbag:=true" \
     "simulation:=true" \
     "use_sim_time:=true" \
-    "run_rviz:=true"
+    "run_rviz:=${RUN_RVIZ:-true}" \
+    "debug:=true"

--- a/aichallenge/run_parallel.bash
+++ b/aichallenge/run_parallel.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Evaluation-environment entrypoint: 3-vehicle parallel race (AWSIM on domain 0, vehicles on 1..3).
+# Self-contained: no docker-entrypoint.sh or compose env is assumed. Per-vehicle overlays
+# (/aichallenge/d1..d3) are sourced by parallel.launch.xml.
+# Contract: docs/interface/evaluation-interface.md §6
+
+ts="$(date +%Y%m%d-%H%M%S)"
+out_dir="/output/${ts}"
+mkdir -p "${out_dir}"
+cd "${out_dir}" || exit
+mkdir -p "${out_dir}/ros/log"
+
+log_file="${out_dir}/autoware.log"
+export ROS_HOME="${out_dir}/ros"
+export ROS_LOG_DIR="${ROS_HOME}/log"
+# Keep launch output in-file while still streaming to container stdout.
+exec > >(tee -a "${log_file}") 2>&1
+
+# shellcheck disable=SC1091
+source /aichallenge/workspace/install/setup.bash
+
+exec ros2 launch aichallenge_system_launch parallel.launch.xml \
+    "log_dir:=${out_dir}"

--- a/aichallenge/run_safety_gate.bash
+++ b/aichallenge/run_safety_gate.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Evaluation-environment entrypoint: safety gate, single vehicle (ROS_DOMAIN_ID 1).
+# Self-contained: no docker-entrypoint.sh or compose env is assumed.
+# Contract: docs/interface/evaluation-interface.md §6
+
+# shellcheck disable=SC1091
+source /aichallenge/workspace/install/setup.bash
+# The evaluation image builds the submission as an overlay under /aichallenge/d1 (aichallenge-aws makefile/Dockerfile);
+# the local eval image builds it into /aichallenge/workspace, so the overlay is optional here.
+if [ -f /aichallenge/d1/workspace/install/setup.bash ]; then
+    # shellcheck disable=SC1091
+    source /aichallenge/d1/workspace/install/setup.bash
+fi
+
+export SIM_MODE=safety-gate
+export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-1}"
+
+exec bash /aichallenge/run_evaluation.bash

--- a/aichallenge/run_safety_gate.bash
+++ b/aichallenge/run_safety_gate.bash
@@ -1,21 +1,9 @@
 #!/usr/bin/env bash
 # Evaluation-environment entrypoint: safety gate, single vehicle (ROS_DOMAIN_ID 1).
-# Self-contained: no docker-entrypoint.sh or compose env is assumed.
+# run_evaluation.bash sources the ROS overlays itself; this wrapper only fixes the mode.
 # Contract: docs/interface/evaluation-interface.md §6
-
-# shellcheck disable=SC1091
-source /aichallenge/workspace/install/setup.bash
-# The evaluation image builds the submission as an overlay under /aichallenge/d1 (aichallenge-aws makefile/Dockerfile);
-# the local eval image builds it into /aichallenge/workspace, so the overlay is optional here.
-if [ -f /aichallenge/d1/workspace/install/setup.bash ]; then
-    # shellcheck disable=SC1091
-    source /aichallenge/d1/workspace/install/setup.bash
-fi
 
 export SIM_MODE=safety-gate
 export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-1}"
-# No rviz in the evaluation environment: capture comes from the standalone screen recorder (full X screen),
-# not from rviz's capture panel, which only records the rviz window region.
-export RUN_RVIZ=false
 
 exec bash /aichallenge/run_evaluation.bash

--- a/aichallenge/run_safety_gate.bash
+++ b/aichallenge/run_safety_gate.bash
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Evaluation-environment entrypoint: safety gate, single vehicle (ROS_DOMAIN_ID 1).
-# run_evaluation.bash sources the ROS overlays itself; this wrapper only fixes the mode.
-# Contract: docs/interface/evaluation-interface.md §6
+# Evaluation-environment entrypoint: safety gate (docs/interface/evaluation-interface.md §6).
 
 export SIM_MODE=safety-gate
 export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-1}"

--- a/aichallenge/run_safety_gate.bash
+++ b/aichallenge/run_safety_gate.bash
@@ -14,5 +14,8 @@ fi
 
 export SIM_MODE=safety-gate
 export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-1}"
+# No rviz in the evaluation environment: capture comes from the standalone screen recorder (full X screen),
+# not from rviz's capture panel, which only records the rviz window region.
+export RUN_RVIZ=false
 
 exec bash /aichallenge/run_evaluation.bash

--- a/aichallenge/simulator_scripts/README.md
+++ b/aichallenge/simulator_scripts/README.md
@@ -26,6 +26,7 @@ make eval → run_evaluation.bash → evaluation.launch.xml
   `make dev2..dev4` は N 台分の autoware を別 compose プロジェクト（ROS_DOMAIN_ID=1..N）で起動する。
 - **セーフティゲートの通し実行の正は `make eval-gate`**（= `SIM_MODE=gate make eval`。
   `evaluation.launch.xml` 経由で orchestrator/rosbag 込みの決勝相当フローを通る）。
+  評価環境は `run_safety_gate.bash` → `safety-gate.sh` を使う（`docs/interface/evaluation-interface.md` §6）。
   `make gate1..gate3` は AWSIM→Autoware 2段起動の単発デバッグ用で、通し検証には使わない。
 
 ## モード一覧
@@ -34,11 +35,12 @@ make eval → run_evaluation.bash → evaluation.launch.xml
 |---|---|---|---|
 | `eval.sh` | 評価 | - | 1台 / 6 laps / 600s / count開始 / handicap・wall-recovery・ranking off |
 | `dev.sh` | 開発 / S2R 練習 | 車両数 N（既定 1） | unlimited laps・timeout / count開始 / handicap・wall-recovery・ranking off / camera・lidar off |
-| `parallel.sh` | 複数台レース | - | 3台 / 6 laps / 600s / sync開始 / handicap・ranking・start-random off / wall-recovery off |
+| `parallel.sh` | 3台並列評価（`parallel.launch.xml` が起動） | - | 3台 / 6 laps / 480s / sync開始 / collisions・handicap・overtaking-lane・ranking on / wall-recovery off |
 | `e2e.sh` | E2E 練習兼提出参考 | - | 1台 + NPC 2体 / 6 laps / timeout 実質なし / count開始（0秒） / start-random on / handicap・ranking off / camera・lidar cpu |
 | `e2e-final.sh` | E2E 決勝 | - | 4台 / 6 laps / 420s / sync開始 / handicap・ranking on / camera・lidar cpu / sound on |
 | `s2r-final.sh` | S2R 決勝 | - | 4台 / 6 laps / 420s / sync開始 / handicap・ranking on / camera・lidar off / sound on |
-| `gate.sh` | Safety Gate テスト | テスト番号 1/2/3/all（既定 all） | 1台。all は test1〜3 を順次実行 |
+| `safety-gate.sh` | Safety Gate 評価（`run_safety_gate.bash` が起動、評価環境の正） | - | 1台 / 全シナリオ / handicap・ranking off / camera・lidar off |
+| `gate.sh` | Safety Gate 単発デバッグ | テスト番号 1/2/3/all（既定 all） | 1台。all は test1〜3 を順次実行 |
 | `sample-scenario.sh` | シナリオ指定起動 | - | `StreamingAssets/Race/official.yaml` を `--scenario` で読み込む |
 | `multiplay-server.sh` | Multiplay 専用サーバー | - | `-batchmode -nographics`、port 7777 |
 | `multiplay-host.sh` | Multiplay ホスト | - | 127.0.0.1:7777、vehicle-index 1 |

--- a/aichallenge/simulator_scripts/README.md
+++ b/aichallenge/simulator_scripts/README.md
@@ -24,6 +24,9 @@ make eval → run_evaluation.bash → evaluation.launch.xml
 - `make dev` / `make gate1..gate3` / `make e2e` は AWSIM に加えて Autoware も起動する複合ターゲット。
   `make e2e` が起動するのは `e2e` モード（`e2e-final` は `make simulator-e2e-final`）。
   `make dev2..dev4` は N 台分の autoware を別 compose プロジェクト（ROS_DOMAIN_ID=1..N）で起動する。
+- **セーフティゲートの通し実行の正は `make eval-gate`**（= `SIM_MODE=gate make eval`。
+  `evaluation.launch.xml` 経由で orchestrator/rosbag 込みの決勝相当フローを通る）。
+  `make gate1..gate3` は AWSIM→Autoware 2段起動の単発デバッグ用で、通し検証には使わない。
 
 ## モード一覧
 

--- a/aichallenge/simulator_scripts/dev.sh
+++ b/aichallenge/simulator_scripts/dev.sh
@@ -20,6 +20,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap off \
     --wall-recovery off \
+    --overtaking-lane off \
     --ranking off \
     --camera off \
     --lidar off

--- a/aichallenge/simulator_scripts/e2e-final.sh
+++ b/aichallenge/simulator_scripts/e2e-final.sh
@@ -18,6 +18,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap on \
     --wall-recovery off \
+    --overtaking-lane off \
     --start-random off \
     --ranking on \
     --camera cpu \

--- a/aichallenge/simulator_scripts/s2r-final.sh
+++ b/aichallenge/simulator_scripts/s2r-final.sh
@@ -18,6 +18,7 @@ exec $AWSIM_DIRECTORY/AWSIM.x86_64 \
     --collisions on \
     --handicap on \
     --wall-recovery off \
+    --overtaking-lane on \
     --start-random off \
     --ranking on \
     --camera off \

--- a/aichallenge/simulator_scripts/safety-gate.sh
+++ b/aichallenge/simulator_scripts/safety-gate.sh
@@ -8,6 +8,7 @@ export ROS_DOMAIN_ID=0
 exec "$AWSIM_DIRECTORY/AWSIM.x86_64" \
     --vehicles 1 \
     --safety-gate "all" \
+    --overtake-lane on \
     --steer-source ackermann \
     --sound off \
     --collisions on \

--- a/aichallenge/simulator_scripts/safety-gate.sh
+++ b/aichallenge/simulator_scripts/safety-gate.sh
@@ -1,24 +1,18 @@
 #!/bin/bash
 
-# Race settings for the 3-vehicle parallel evaluation (parallel.launch.xml).
+# Safety gate for the evaluation environment (run_safety_gate.bash): all scenarios, fixed args.
+# For per-test debugging use gate.sh (make gate1..gate3).
 AWSIM_DIRECTORY=/aichallenge/simulator/AWSIM
 export ROS_DOMAIN_ID=0
 
 exec "$AWSIM_DIRECTORY/AWSIM.x86_64" \
-    --start-mode sync \
-    --start-count-seconds 5 \
-    --vehicles 3 \
-    --npcs 0 \
-    --boosts 2 \
-    --laps 6 \
-    --timeout 480 \
+    --vehicles 1 \
+    --safety-gate "all" \
     --steer-source ackermann \
     --sound off \
     --collisions on \
-    --handicap on \
-    --wall-recovery off \
-    --overtaking-lane on \
-    --ranking on \
+    --handicap off \
+    --ranking off \
     --camera off \
     --lidar off \
     -screen-fullscreen 1 \

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
@@ -3,7 +3,6 @@
     <arg name="simulation"/>
     <arg name="use_sim_time"/>
     <arg name="run_rviz"/>
-    <!-- Debug visualization / motion analytics (awsim.launch.xml). Defaults to run_rviz so local runs are unchanged. -->
     <arg name="debug" default="$(var run_rviz)"/>
     <arg name="sensor_model" default="racing_kart_sensor_kit"/>
     <arg name="launch_vehicle_interface" default="$(eval &quot;'$(var simulation)' == 'false'&quot;)"/>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/aichallenge_system.launch.xml
@@ -3,6 +3,8 @@
     <arg name="simulation"/>
     <arg name="use_sim_time"/>
     <arg name="run_rviz"/>
+    <!-- Debug visualization / motion analytics (awsim.launch.xml). Defaults to run_rviz so local runs are unchanged. -->
+    <arg name="debug" default="$(var run_rviz)"/>
     <arg name="sensor_model" default="racing_kart_sensor_kit"/>
     <arg name="launch_vehicle_interface" default="$(eval &quot;'$(var simulation)' == 'false'&quot;)"/>
     <arg name="capture" default="false"/>
@@ -48,7 +50,7 @@
         <include file="$(find-pkg-share aichallenge_system_launch)/launch/mode/awsim.launch.xml">
             <arg name="capture" value="$(var capture)"/>
             <arg name="rosbag" value="$(var rosbag)"/>
-            <arg name="debug" value="$(var run_rviz)"/>
+            <arg name="debug" value="$(var debug)"/>
         </include>
     </group>
 

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/evaluation.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/evaluation.launch.xml
@@ -22,6 +22,8 @@
     <group>
         <group>
             <set_env name="ROS_DOMAIN_ID" value="0"/>
+            <!-- run_simulator.bash writes awsim.log under LOG_DIR. -->
+            <set_env name="LOG_DIR" value="$(var log_dir)"/>
             <executable
                 name="aichallenge_awsim_eval"
                 cwd="$(var log_dir)"

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/evaluation.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/evaluation.launch.xml
@@ -8,7 +8,7 @@
     <arg name="simulation" default="true"/>
     <arg name="use_sim_time" default="true"/>
     <arg name="run_rviz" default="true"/>
-    <!-- Debug visualization / motion analytics; independent of rviz so the evaluation can keep it on with rviz off. -->
+    <!-- Debug visualization / motion analytics (awsim.launch.xml); independent of rviz. -->
     <arg name="debug" default="$(var run_rviz)"/>
 
     <log message="Launching evaluation bundle (simulator + autoware)."/>
@@ -38,9 +38,8 @@
         </group>
     </group>
 
-    <!-- Screen capture without rviz: the standalone recorder grabs the X root window (full 1280x720),
-         whereas rviz's AutowareScreenCapturePanel records only the rviz window region. With rviz on,
-         the panel provides /debug/service/capture_screen, so the recorder is skipped to avoid two servers. -->
+    <!-- Standalone recorder (X root window). With rviz on, its AutowareScreenCapturePanel already serves
+         /debug/service/capture_screen, so the recorder is skipped to avoid two servers. -->
     <group if="$(var capture)">
         <group unless="$(var run_rviz)">
             <set_env name="ROS_DOMAIN_ID" value="$(var domain_id)"/>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/evaluation.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/evaluation.launch.xml
@@ -8,6 +8,8 @@
     <arg name="simulation" default="true"/>
     <arg name="use_sim_time" default="true"/>
     <arg name="run_rviz" default="true"/>
+    <!-- Debug visualization / motion analytics; independent of rviz so the evaluation can keep it on with rviz off. -->
+    <arg name="debug" default="$(var run_rviz)"/>
 
     <log message="Launching evaluation bundle (simulator + autoware)."/>
     <log message=" - domain_id: $(var domain_id)"/>
@@ -18,6 +20,7 @@
     <log message=" - simulation: $(var simulation)"/>
     <log message=" - use_sim_time: $(var use_sim_time)"/>
     <log message=" - run_rviz: $(var run_rviz)"/>
+    <log message=" - debug: $(var debug)"/>
 
     <group>
         <group>
@@ -30,7 +33,19 @@
                 output="both"
                 cmd="bash /aichallenge/run_simulator.bash $(var sim_mode)"/>
             <include file="$(find-pkg-share aichallenge_system_launch)/launch/mode/awsim_state_manager.launch.xml">
-                <arg name="debug" value="$(var run_rviz)"/>
+                <arg name="debug" value="$(var debug)"/>
+            </include>
+        </group>
+    </group>
+
+    <!-- Screen capture without rviz: the standalone recorder grabs the X root window (full 1280x720),
+         whereas rviz's AutowareScreenCapturePanel records only the rviz window region. With rviz on,
+         the panel provides /debug/service/capture_screen, so the recorder is skipped to avoid two servers. -->
+    <group if="$(var capture)">
+        <group unless="$(var run_rviz)">
+            <set_env name="ROS_DOMAIN_ID" value="$(var domain_id)"/>
+            <include file="$(find-pkg-share aichallenge_screen_recorder)/launch/screen_recorder.launch.xml">
+                <arg name="output_dir" value="$(var log_dir)/capture"/>
             </include>
         </group>
     </group>
@@ -41,6 +56,7 @@
             <arg name="simulation" value="$(var simulation)"/>
             <arg name="use_sim_time" value="$(var use_sim_time)"/>
             <arg name="run_rviz" value="$(var run_rviz)"/>
+            <arg name="debug" value="$(var debug)"/>
             <arg name="capture" value="$(var capture)"/>
             <arg name="rosbag" value="$(var rosbag)"/>
             <arg name="domain_id" value="$(var domain_id)"/>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/parallel.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/parallel.launch.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+    <!-- AWSIM race settings (vehicles, laps, timeout, penalties, ...) live in simulator_scripts/parallel.sh. -->
+    <arg name="log_dir" default="/output"/>
+    <arg name="capture" default="true"/>
+    <arg name="rosbag" default="true"/>
+    <arg name="simulation" default="true"/>
+    <arg name="use_sim_time" default="true"/>
+    <arg name="run_rviz" default="false"/>
+    <!-- CPU affinity and memory limits tuned for g4dn.4xlarge (16 vCPUs with uniform performance, 64 GB RAM).
+         mem_* args are passed to prlimit as, which limits virtual address space (VAS), not RSS.
+         CPU 0 is intentionally left unallocated for the OS and system daemons. -->
+    <arg name="cpu_awsim" default="1-4"/>
+    <arg name="mem_awsim" default="unlimited"/>
+    <arg name="cpu_screen_recorder" default="5-6"/>
+    <arg name="mem_screen_recorder" default="unlimited"/>
+    <arg name="cpu_d1" default="7-9"/>
+    <arg name="mem_d1" default="12884901888"/> <!-- 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G) here -->
+    <arg name="cpu_d2" default="10-12"/>
+    <arg name="mem_d2" default="12884901888"/> <!-- 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G) here -->
+    <arg name="cpu_d3" default="13-15"/>
+    <arg name="mem_d3" default="12884901888"/> <!-- 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G) here -->
+
+    <log message="Launching parallel evaluation (AWSIM args: simulator_scripts/parallel.sh)."/>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="0"/>
+        <!-- run_simulator.bash writes awsim.log under LOG_DIR. -->
+        <set_env name="LOG_DIR" value="$(var log_dir)"/>
+
+        <executable
+            name="aichallenge_awsim_eval"
+            cwd="$(var log_dir)"
+            output="both"
+            cmd="prlimit --as=$(var mem_awsim) taskset -c $(var cpu_awsim) bash /aichallenge/run_simulator.bash parallel"/>
+        <include file="$(find-pkg-share aichallenge_system_launch)/launch/mode/awsim_state_manager.launch.xml"/>
+        <executable name="resource_monitor" output="log" cmd="$(find-pkg-prefix aichallenge_system_launch)/lib/aichallenge_system_launch/resource_monitor.sh $(var log_dir)/d1/autoware.log"/>
+    </group>
+
+    <!-- Standalone Qt screen recorder (replaces rviz AutowareScreenCapturePanel). -->
+    <group if="$(var capture)">
+        <set_env name="ROS_DOMAIN_ID" value="1"/>
+        <let name="screen_recorder_prefix" value="prlimit --as=$(var mem_screen_recorder) taskset -c $(var cpu_screen_recorder)"/>
+        <include file="$(find-pkg-share aichallenge_screen_recorder)/launch/screen_recorder.launch.xml">
+            <arg name="output_dir" value="$(var log_dir)/capture"/>
+            <arg name="launch_prefix" value="$(var screen_recorder_prefix)"/>
+        </include>
+    </group>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="1"/>
+        <set_env name="ROS_HOME" value="$(var log_dir)/d1/ros"/>
+        <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d1/ros/log"/>
+        <executable name="autoware_d1" output="log" cmd="prlimit --as=$(var mem_d1) taskset -c $(var cpu_d1) bash -c 'mkdir -p '$(var log_dir)'/d1 &amp;&amp; cd '$(var log_dir)'/d1 &amp;&amp; source /aichallenge/workspace/install/setup.bash &amp;&amp; source /aichallenge/d1/workspace/install/setup.bash &amp;&amp; exec ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=false capture:=true rosbag:=true domain_id:=1 &gt; '$(var log_dir)'/d1/autoware.log 2&gt;&amp;1'"/>
+    </group>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="2"/>
+        <set_env name="ROS_HOME" value="$(var log_dir)/d2/ros"/>
+        <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d2/ros/log"/>
+        <executable name="autoware_d2" output="log" cmd="prlimit --as=$(var mem_d2) taskset -c $(var cpu_d2) bash -c '[ -f /aichallenge/d2/workspace/install/setup.bash ] || exit 0; mkdir -p '$(var log_dir)'/d2 &amp;&amp; cd '$(var log_dir)'/d2 &amp;&amp; source /aichallenge/workspace/install/setup.bash &amp;&amp; source /aichallenge/d2/workspace/install/setup.bash &amp;&amp; exec ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=false capture:=false rosbag:=false domain_id:=2 &gt; '$(var log_dir)'/d2/autoware.log 2&gt;&amp;1'"/>
+    </group>
+
+    <group>
+        <set_env name="ROS_DOMAIN_ID" value="3"/>
+        <set_env name="ROS_HOME" value="$(var log_dir)/d3/ros"/>
+        <set_env name="ROS_LOG_DIR" value="$(var log_dir)/d3/ros/log"/>
+        <executable name="autoware_d3" output="log" cmd="prlimit --as=$(var mem_d3) taskset -c $(var cpu_d3) bash -c '[ -f /aichallenge/d3/workspace/install/setup.bash ] || exit 0; mkdir -p '$(var log_dir)'/d3 &amp;&amp; cd '$(var log_dir)'/d3 &amp;&amp; source /aichallenge/workspace/install/setup.bash &amp;&amp; source /aichallenge/d3/workspace/install/setup.bash &amp;&amp; exec ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=false capture:=false rosbag:=false domain_id:=3 &gt; '$(var log_dir)'/d3/autoware.log 2&gt;&amp;1'"/>
+    </group>
+
+</launch>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/parallel.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/launch/parallel.launch.xml
@@ -14,12 +14,13 @@
     <arg name="mem_awsim" default="unlimited"/>
     <arg name="cpu_screen_recorder" default="5-6"/>
     <arg name="mem_screen_recorder" default="unlimited"/>
+    <!-- mem_d*: 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G). -->
     <arg name="cpu_d1" default="7-9"/>
-    <arg name="mem_d1" default="12884901888"/> <!-- 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G) here -->
+    <arg name="mem_d1" default="12884901888"/>
     <arg name="cpu_d2" default="10-12"/>
-    <arg name="mem_d2" default="12884901888"/> <!-- 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G) here -->
+    <arg name="mem_d2" default="12884901888"/>
     <arg name="cpu_d3" default="13-15"/>
-    <arg name="mem_d3" default="12884901888"/> <!-- 12 GiB in bytes; prlimit does not accept unit suffixes (e.g. 12G) here -->
+    <arg name="mem_d3" default="12884901888"/>
 
     <log message="Launching parallel evaluation (AWSIM args: simulator_scripts/parallel.sh)."/>
 

--- a/docs/interface/evaluation-interface.md
+++ b/docs/interface/evaluation-interface.md
@@ -48,7 +48,7 @@
 12. **`dN-result-details.json` の配置は AWSIM の CWD に従う（固定の `d0/` 前提でパスを決め打ちしない）。`result-summary.json` は `autostart_orchestrator` が `output_dir / "result-summary.json"` と `run_dir / "result-summary.json"` の両方を探索する（ソース: `_refresh_latest_artifact_links`）。この探索ロジックを変更する場合は配置パターンと整合させること。** 守らないと `latest/` へのシンボリックリンクが張れず、最新成果物の特定手段が失われる。
 
 
-13. **評価パイプライン（`aichallenge-aws` の `main.bash`）が起動するのは `aichallenge/run_safety_gate.bash` と `aichallenge/run_parallel.bash` の 2 本だけ。両者は自己完結（ROS overlay を自分で source し、`SIM_MODE` / `ROS_DOMAIN_ID` / `LOG_DIR` を自分で決める）で、`docker-entrypoint.sh` や compose の環境変数に依存しない。名前・引数なし起動・自己完結性を変更しない。** 守らないと評価イメージ（entrypoint 無し、提出物は `/aichallenge/d1` overlay）で `ros2: command not found` や提出パッケージ未検出で全件 failed になる（2026-09-02 に実際に発生）。ローカル開発用の `run_evaluation.bash` / `run_autoware.bash` はこの契約の対象外で、変更してよいが、入口スクリプトが exec する先である点は保つ（§6）。
+13. **評価パイプライン（`aichallenge-aws` の `main.bash`）は `EVAL_ENTRYPOINT` で指定された入口スクリプトを `bash /aichallenge/<EVAL_ENTRYPOINT>` で起動する。入口は `run_evaluation.bash`（s2r_1_practice_solo）、`run_safety_gate.bash`（s2r_2_practice_solo）、`run_parallel.bash`（s2r_1_rated_trios）の 3 本だけ。各入口は ROS overlay を自分で source し、`SIM_MODE` / `ROS_DOMAIN_ID` / `LOG_DIR` を自分で決める（`docker-entrypoint.sh` や compose の環境変数に依存しない）。評価環境側が渡すのは `EVAL_ENTRYPOINT` / `EVAL_TIMEOUT_SEC` / `RUN_RVIZ=false` と Batch 固有の env のみ。名前・引数なし起動・自己完結性を変更しない。** 守らないと評価イメージ（entrypoint 無し、提出物は `/aichallenge/d1` overlay）で `ros2: command not found` や提出パッケージ未検出で全件 failed になる（2026-09-02 に実際に発生）。
 ---
 
 ## 2. ドメイン規約の約束
@@ -231,24 +231,26 @@ AWS `result_update` Lambda は `vehicles[].vehicle_number` と `vehicles[].final
 
 ### 6-1. 入口スクリプト
 
-| 入口 | 用途 | 中で行うこと | AWS 側の選択条件 |
+`aichallenge-aws` の `start_build` Lambda が `evaluation_mode` を入口名とタイムアウトに変換し、Step Functions が Batch コンテナの env（`EVAL_ENTRYPOINT`, `EVAL_TIMEOUT_SEC`）として渡す。`main.bash` は許可リストで名前を検証してから起動する。
+
+| evaluation_mode | EVAL_ENTRYPOINT | 中で行うこと | EVAL_TIMEOUT_SEC |
 |---|---|---|---|
-| `aichallenge/run_safety_gate.bash` | セーフティゲート（1 台、`evaluation_mode: s2r_2_practice_solo`） | base overlay を source → `/aichallenge/d1/workspace/install/setup.bash` があれば source → `SIM_MODE=safety-gate`、`ROS_DOMAIN_ID=1` を設定 → `exec bash run_evaluation.bash` | `PARALLEL_MODE != true` |
-| `aichallenge/run_parallel.bash` | 3 台並列レース（`evaluation_mode: s2r_1_rated_trios`） | base overlay を source → `exec ros2 launch parallel.launch.xml log_dir:=/output/<ts>`（各車両の `d1..d3` overlay は launch 内で source） | `PARALLEL_MODE == true` |
+| `s2r_1_practice_solo` | `run_evaluation.bash` | base overlay を source → `/aichallenge/d1/workspace/install/setup.bash` があれば source → `SIM_MODE`（既定 `eval` = `eval.sh`）で `evaluation.launch.xml` | 800 |
+| `s2r_2_practice_solo` | `run_safety_gate.bash` | `SIM_MODE=safety-gate`、`ROS_DOMAIN_ID=1` を設定 → `exec bash run_evaluation.bash` | 400 |
+| `s2r_1_rated_trios` | `run_parallel.bash` | base overlay を source → `exec ros2 launch parallel.launch.xml log_dir:=/output/<ts>`（各車両の `d1..d3` overlay は launch 内で source） | 800 |
 
 ### 6-2. 入口スクリプトが守ること
 
 - **引数なしで起動できる。** 評価環境から渡されるのは環境変数のみ（`EVAL_TIMEOUT_SEC` は `main.bash` の `timeout` に使われ、入口には渡らない）。
-- **ROS 環境を自分で整える。** `/aichallenge/workspace/install/setup.bash` を必ず source し、`d1` overlay は存在すれば source する（ローカル eval イメージでは存在しないので条件付き）。
-- **`SIM_MODE` を自分で決める。** 入口 = モードなので、外から渡された `SIM_MODE` は上書きする。AWSIM の引数は `simulator_scripts/<mode>.sh` に置き、入口や launch に直接書かない（`safety-gate.sh` / `parallel.sh`）。
-- **rviz は起動しない（`RUN_RVIZ=false`）。** 録画は standalone の `aichallenge_screen_recorder`（X root window 全体 = 1280x720）で行う。rviz が居ると Autoware 標準の AutowareScreenCapturePanel が同じ `/debug/service/capture_screen` を提供し、rviz ウィンドウ領域（1850x1136、オフセット 70,27）しか録れない。`evaluation.launch.xml` は `run_rviz=false` かつ `capture=true` のときだけ recorder を起動する。debug 可視化 / motion analytics は `debug` 引数で独立に on。
-- **出力レイアウトは §5 に従う。** gate は `/output/<ts>/d1/`（`result-summary.json` も同じ場所）、parallel は `/output/<ts>/`（`result-summary.json` は run_dir 直下、車両ログは `d1..d3/`）。
-- **完了は `/admin/awsim/state` で通知する。** gate は AWSIM の自己終了時 `terminate`、parallel は `finishall`。入口が自分で結果をアップロードしたり、`/output` 以外に書いたりしない。
-- **ローカルの `make eval-gate` は `run_evaluation.bash` + `SIM_MODE=gate`（`gate.sh`）で、入口スクリプトは通らない。** 評価環境と同じ入口をローカルで試すときは eval イメージ内で `bash /aichallenge/run_safety_gate.bash` を直接実行する。
+- **ROS 環境を自分で整える。** `/aichallenge/workspace/install/setup.bash` を必ず source し、単体系は `d1` overlay が存在すれば source する（ローカル eval イメージでは存在しないので条件付き）。この処理は `run_evaluation.bash` に置き、`run_safety_gate.bash` はモード指定だけの薄い wrapper にする。
+- **`SIM_MODE` を自分で決める。** 入口 = モードなので、外から渡された `SIM_MODE` は上書きする。AWSIM の引数は `simulator_scripts/<mode>.sh` に置き、入口や launch に直接書かない（`eval.sh` / `safety-gate.sh` / `parallel.sh`）。
+- **rviz は評価環境側が切る（`RUN_RVIZ=false` を `main.bash` が export）。** 録画は standalone の `aichallenge_screen_recorder`（X root window 全体 = 1280x720）で行う。rviz が居ると Autoware 標準の AutowareScreenCapturePanel が同じ `/debug/service/capture_screen` を提供し、rviz ウィンドウ領域（1850x1136、オフセット 70,27）しか録れない。`evaluation.launch.xml` は `run_rviz=false` かつ `capture=true` のときだけ recorder を起動する。debug 可視化 / motion analytics は `debug` 引数で独立に on。
+- **出力レイアウトは §5 に従う。** 単体系は `/output/<ts>/d1/`（`result-summary.json` も同じ場所）、parallel は `/output/<ts>/`（`result-summary.json` は run_dir 直下、車両ログは `d1..d3/`）。
+- **完了は `/admin/awsim/state` で通知する。** gate は AWSIM の自己終了時 `terminate`、レース系は `finishall`。入口が自分で結果をアップロードしたり、`/output` 以外に書いたりしない。
 
 ### 6-3. 変更時の手順
 
-入口の名前・数・自己完結性を変えるときは、(1) 本節と約束 13 を更新、(2) `aichallenge-aws/makefile/main.bash` の起動分岐を合わせる、(3) base image（`aichallenge-aws/base_image`）を stg から再ビルドして push、(4) `makefile/deploy.sh` で `main.bash` を反映、の順で行う。base image は `aichallenge/` を丸ごと取り込むため、入口スクリプトは base image 再ビルドまで評価環境に届かない。
+入口の名前・数・自己完結性を変えるときは、(1) 本節と約束 13 を更新、(2) `aichallenge-aws` の `start_build`（mode → 入口の表）と `makefile/main.bash` の許可リストを合わせる、(3) base image（`aichallenge-aws/base_image`）を stg から再ビルドして push、(4) `makefile/deploy.sh` で `main.bash` を反映、の順で行う。base image は `aichallenge/` を丸ごと取り込むため、入口スクリプトは base image 再ビルドまで評価環境に届かない。
 
 ---
 

--- a/docs/interface/evaluation-interface.md
+++ b/docs/interface/evaluation-interface.md
@@ -42,7 +42,7 @@
 
 10. **`HOST_UID` / `HOST_GID` を Makefile が export し、`output/` 配下の成果物がホストユーザ所有になる。コンテナを直接 `docker compose` で起動する場合も `HOST_UID` / `HOST_GID` を渡すこと。** 守らないと `output/` が root 所有になり、ホストで成果物を参照/削除できなくなる。
 
-11. **`dN-result-details.json` のファイル名接頭辞 `d{vehicle_number}-` と `schema_version: "v3"`、`result-summary.json` のファイル名と `schema_version: "v2"`、`vehicles[].vehicle_number`、`vehicles[].final_position` は変更しない。** 守らないと AWS `result_update` Lambda がファイル検索に失敗するか、スコアリングが壊れる。`result-summary.json` はファイル名が Lambda の S3 イベント発火条件であり固定。
+11. **`dN-result-details.json` のファイル名接頭辞 `d{vehicle_number}-` と `schema_version: "v3"`、`result-summary.json` のファイル名と `schema_version: "v2"`（レースモード。セーフティゲートモードは `"safety-gate-v1"`、§5 参照）、`vehicles[].vehicle_number`、`vehicles[].final_position` は変更しない。** 守らないと AWS `result_update` Lambda がファイル検索に失敗するか、スコアリングが壊れる。`result-summary.json` はファイル名が Lambda の S3 イベント発火条件であり固定。
 
 12. **`dN-result-details.json` の配置は AWSIM の CWD に従う（固定の `d0/` 前提でパスを決め打ちしない）。`result-summary.json` は `autostart_orchestrator` が `output_dir / "result-summary.json"` と `run_dir / "result-summary.json"` の両方を探索する（ソース: `_refresh_latest_artifact_links`）。この探索ロジックを変更する場合は配置パターンと整合させること。** 守らないと `latest/` へのシンボリックリンクが張れず、最新成果物の特定手段が失われる。
 
@@ -180,6 +180,34 @@ result JSON の**生産者は AWSIM（Unity）シミュレータ本体**。`scri
 `vehicles[]` 要素: `vehicle_number` (int)、`vehicle_name` (string)、`final_position` (int, 1 始まり)、`finished` (bool)、`lap_count` (int)、`laps` (float[] 秒)、`min_lap_time` / `max_lap_time` / `avg_lap_time` / `total_lap_time` (float 秒)。`final_position` は MCR（"1334" 形式）: 同着はグループ最小順位を共有するため値が飛びうる（順位付けアルゴリズム自体は AWSIM 側にあり本リポジトリのソースには無く、実サンプル出力から確認）。
 
 AWS `result_update` Lambda は `vehicles[].vehicle_number` と `vehicles[].final_position` のみを消費してスコア（Elo レーティング）を算出する。
+
+##### セーフティゲートモードの `result-summary.json`（2026-09 追加）
+
+セーフティゲート実行（`SIM_MODE=gate*`、`evaluation_mode: s2r_2_practice_solo`）では、AWSIM は
+レースを走らせないため通常の summary は生成せず、代わりに **gate 版 summary** を CWD に書き出す。
+完了契約（「summary を最後にアップロード → `result_update` 発火」）は全モード共通:
+
+```json
+{
+  "schema_version": "safety-gate-v1",
+  "safety_gate": {
+    "all_passed": true,
+    "gate_arg": "all",
+    "scenario_folder": "SafetyGate",
+    "tests": [{ "test_name": "test1", "passed": true, "fail_reason": "" }]
+  },
+  "vehicles": []
+}
+```
+
+- `safety_gate` キーの有無がモード判別子。**レース用フィールドの偽装は禁止**（`vehicles` は空配列。
+  `final_position` / `laps` のダミー値を入れない）。
+- `schema_version` はレース用 `"v2"` と区別するため `"safety-gate-v1"` 固定。gate 版 summary は
+  `safety_gate` + `vehicles` しか持たないので、v2（session + legacy projection）契約でパースしてはならない
+  （AWS `result_update` は `schema_version` を読まず `vehicles[].final_position` のみ参照するため影響なし）。
+- `vehicles: []` のため `result_update` の順位パースは安全に None を返し、`executions.status=2` と
+  raw JSON の `result` 列保存のみが行われる（レーティングは `evaluation_mode` ガードで不変）。
+- 人間/デバッグ用の `safety-gate-result.json` も従来どおり CWD に併存する（S3 へはアップロードしない）。
 
 ---
 

--- a/docs/interface/evaluation-interface.md
+++ b/docs/interface/evaluation-interface.md
@@ -241,6 +241,7 @@ AWS `result_update` Lambda は `vehicles[].vehicle_number` と `vehicles[].final
 - **引数なしで起動できる。** 評価環境から渡されるのは環境変数のみ（`EVAL_TIMEOUT_SEC` は `main.bash` の `timeout` に使われ、入口には渡らない）。
 - **ROS 環境を自分で整える。** `/aichallenge/workspace/install/setup.bash` を必ず source し、`d1` overlay は存在すれば source する（ローカル eval イメージでは存在しないので条件付き）。
 - **`SIM_MODE` を自分で決める。** 入口 = モードなので、外から渡された `SIM_MODE` は上書きする。AWSIM の引数は `simulator_scripts/<mode>.sh` に置き、入口や launch に直接書かない（`safety-gate.sh` / `parallel.sh`）。
+- **rviz は起動しない（`RUN_RVIZ=false`）。** 録画は standalone の `aichallenge_screen_recorder`（X root window 全体 = 1280x720）で行う。rviz が居ると Autoware 標準の AutowareScreenCapturePanel が同じ `/debug/service/capture_screen` を提供し、rviz ウィンドウ領域（1850x1136、オフセット 70,27）しか録れない。`evaluation.launch.xml` は `run_rviz=false` かつ `capture=true` のときだけ recorder を起動する。debug 可視化 / motion analytics は `debug` 引数で独立に on。
 - **出力レイアウトは §5 に従う。** gate は `/output/<ts>/d1/`（`result-summary.json` も同じ場所）、parallel は `/output/<ts>/`（`result-summary.json` は run_dir 直下、車両ログは `d1..d3/`）。
 - **完了は `/admin/awsim/state` で通知する。** gate は AWSIM の自己終了時 `terminate`、parallel は `finishall`。入口が自分で結果をアップロードしたり、`/output` 以外に書いたりしない。
 - **ローカルの `make eval-gate` は `run_evaluation.bash` + `SIM_MODE=gate`（`gate.sh`）で、入口スクリプトは通らない。** 評価環境と同じ入口をローカルで試すときは eval イメージ内で `bash /aichallenge/run_safety_gate.bash` を直接実行する。

--- a/docs/interface/evaluation-interface.md
+++ b/docs/interface/evaluation-interface.md
@@ -8,13 +8,14 @@
 
 ## 1. 概要（この契約が何を保証するか）
 
-この契約は以下の 5 つの面を固定します。
+この契約は以下の 6 つの面を固定します。
 
 1. **ROS 2 ドメイン規約** — AWSIM が Domain 0、車両 Autoware が Domain 1..N に固定
 2. **admin/awsim トピック** — スタート・リセット・状態遷移を駆動するトピックの名前・型・所有者
 3. **ノード責務分離** — `awsim_state_manager_node` と `autostart_orchestrator_node` の境界
 4. **成果物・ログレイアウト** — `/output` 配下のディレクトリ構造とシンボリックリンク
 5. **result JSON スキーマ** — `result-summary.json`（schema v2）と `dN-result-details.json`（schema v3）のキー
+6. **評価環境の入口（entrypoint）** — 評価パイプラインが起動するスクリプトの名前と、それが自己完結で満たす前提
 
 いずれかを変更すると、評価パイプライン・複数車両ランの分離・スコアリング Lambda のいずれかが機能しなくなります。
 
@@ -46,6 +47,8 @@
 
 12. **`dN-result-details.json` の配置は AWSIM の CWD に従う（固定の `d0/` 前提でパスを決め打ちしない）。`result-summary.json` は `autostart_orchestrator` が `output_dir / "result-summary.json"` と `run_dir / "result-summary.json"` の両方を探索する（ソース: `_refresh_latest_artifact_links`）。この探索ロジックを変更する場合は配置パターンと整合させること。** 守らないと `latest/` へのシンボリックリンクが張れず、最新成果物の特定手段が失われる。
 
+
+13. **評価パイプライン（`aichallenge-aws` の `main.bash`）が起動するのは `aichallenge/run_safety_gate.bash` と `aichallenge/run_parallel.bash` の 2 本だけ。両者は自己完結（ROS overlay を自分で source し、`SIM_MODE` / `ROS_DOMAIN_ID` / `LOG_DIR` を自分で決める）で、`docker-entrypoint.sh` や compose の環境変数に依存しない。名前・引数なし起動・自己完結性を変更しない。** 守らないと評価イメージ（entrypoint 無し、提出物は `/aichallenge/d1` overlay）で `ros2: command not found` や提出パッケージ未検出で全件 failed になる（2026-09-02 に実際に発生）。ローカル開発用の `run_evaluation.bash` / `run_autoware.bash` はこの契約の対象外で、変更してよいが、入口スクリプトが exec する先である点は保つ（§6）。
 ---
 
 ## 2. ドメイン規約の約束
@@ -131,7 +134,7 @@ output/
 
 > 注: AWSIM はレース結果（`result-summary.json` / `dN-result-details.json`）を **自身の CWD** に書き出す。配置はフローで異なる:
 > - **dev / 並列（`run_simulator.bash`）**: AWSIM の CWD = run_dir 直下。`awsim.log` も `${LOG_DIR}/awsim.log`（run_dir 直下）。実サンプル `output/20260607-235456/` では `awsim.log`・`d1..d4-result-details.json`・`result-summary.json` が全て run_dir 直下にあり、`d0/` は存在しない。
-> - **eval（`run_evaluation.bash`）**: `cd "${out_dir}"`（= `d<N>/`）してから launch するため AWSIM の CWD = `d<N>/`。
+> - **eval / safety gate（`run_evaluation.bash`、`run_safety_gate.bash`）**: `cd "${out_dir}"`（= `d<N>/`）してから launch するため AWSIM の CWD = `d<N>/`。`evaluation.launch.xml` が `LOG_DIR=log_dir`（= `d<N>/`）を渡すので `awsim.log` も `d<N>/` に入る。
 >
 > `d0/` というディレクトリは生成されない。固定前提でパスを決め打ちせず、`autostart_orchestrator` の探索（約束 12）に従うこと。
 
@@ -211,7 +214,44 @@ AWS `result_update` Lambda は `vehicles[].vehicle_number` と `vehicles[].final
 
 ---
 
-## 6. 関連ドキュメント
+## 6. 評価環境の入口（entrypoint）契約
+
+ソース確認先: `aichallenge/run_safety_gate.bash`、`aichallenge/run_parallel.bash`、`aichallenge-aws/makefile/main.bash`、`aichallenge-aws/makefile/Dockerfile`
+
+評価環境（AWS Batch 上の評価イメージ）とローカル開発環境は、同じ `aichallenge/` を使いながら前提が異なる。
+
+| 前提 | ローカル（`docker compose` / `make eval*`） | 評価環境（`aichallenge-aws`） |
+|---|---|---|
+| ROS overlay の source | `docker-entrypoint.sh`（ENTRYPOINT / `.bashrc`）が行う | ENTRYPOINT 無し。`main.bash` は `bash <entrypoint>` を呼ぶだけ |
+| 提出物の配置 | `/aichallenge/workspace/src/aichallenge_submit`（1 つの workspace） | `/aichallenge/d1/workspace`（挑戦者）、`d2` / `d3`（対戦相手 / NPC）を base の上に overlay |
+| AWSIM 起動引数 | `simulator_scripts/<SIM_MODE>.sh` | 同じ（`run_simulator.bash` 経由） |
+| 完了シグナル | 人が `make down` | `/admin/awsim/state` の `terminate`（gate）/ `finishall`（parallel）を `main.bash` が監視し、grace 後にアップロード |
+
+この差を吸収する層が **評価環境の入口スクリプト** である。ローカル用スクリプト（`run_evaluation.bash` など）を評価環境から直接呼ばない。
+
+### 6-1. 入口スクリプト
+
+| 入口 | 用途 | 中で行うこと | AWS 側の選択条件 |
+|---|---|---|---|
+| `aichallenge/run_safety_gate.bash` | セーフティゲート（1 台、`evaluation_mode: s2r_2_practice_solo`） | base overlay を source → `/aichallenge/d1/workspace/install/setup.bash` があれば source → `SIM_MODE=safety-gate`、`ROS_DOMAIN_ID=1` を設定 → `exec bash run_evaluation.bash` | `PARALLEL_MODE != true` |
+| `aichallenge/run_parallel.bash` | 3 台並列レース（`evaluation_mode: s2r_1_rated_trios`） | base overlay を source → `exec ros2 launch parallel.launch.xml log_dir:=/output/<ts>`（各車両の `d1..d3` overlay は launch 内で source） | `PARALLEL_MODE == true` |
+
+### 6-2. 入口スクリプトが守ること
+
+- **引数なしで起動できる。** 評価環境から渡されるのは環境変数のみ（`EVAL_TIMEOUT_SEC` は `main.bash` の `timeout` に使われ、入口には渡らない）。
+- **ROS 環境を自分で整える。** `/aichallenge/workspace/install/setup.bash` を必ず source し、`d1` overlay は存在すれば source する（ローカル eval イメージでは存在しないので条件付き）。
+- **`SIM_MODE` を自分で決める。** 入口 = モードなので、外から渡された `SIM_MODE` は上書きする。AWSIM の引数は `simulator_scripts/<mode>.sh` に置き、入口や launch に直接書かない（`safety-gate.sh` / `parallel.sh`）。
+- **出力レイアウトは §5 に従う。** gate は `/output/<ts>/d1/`（`result-summary.json` も同じ場所）、parallel は `/output/<ts>/`（`result-summary.json` は run_dir 直下、車両ログは `d1..d3/`）。
+- **完了は `/admin/awsim/state` で通知する。** gate は AWSIM の自己終了時 `terminate`、parallel は `finishall`。入口が自分で結果をアップロードしたり、`/output` 以外に書いたりしない。
+- **ローカルの `make eval-gate` は `run_evaluation.bash` + `SIM_MODE=gate`（`gate.sh`）で、入口スクリプトは通らない。** 評価環境と同じ入口をローカルで試すときは eval イメージ内で `bash /aichallenge/run_safety_gate.bash` を直接実行する。
+
+### 6-3. 変更時の手順
+
+入口の名前・数・自己完結性を変えるときは、(1) 本節と約束 13 を更新、(2) `aichallenge-aws/makefile/main.bash` の起動分岐を合わせる、(3) base image（`aichallenge-aws/base_image`）を stg から再ビルドして push、(4) `makefile/deploy.sh` で `main.bash` を反映、の順で行う。base image は `aichallenge/` を丸ごと取り込むため、入口スクリプトは base image 再ビルドまで評価環境に届かない。
+
+---
+
+## 7. 関連ドキュメント
 
 - ログ設計（`/output` 詳細・ローテーション方針・rosbag 安全停止）: [`../spec/log-design.md`](../spec/log-design.md)
 - Compose オーバーレイ選択（`COMPOSE_FILE` の GPU/CPU/headless）: [`../spec/compose-overlays.md`](../spec/compose-overlays.md)

--- a/docs/interface/evaluation-interface.md
+++ b/docs/interface/evaluation-interface.md
@@ -48,7 +48,7 @@
 12. **`dN-result-details.json` の配置は AWSIM の CWD に従う（固定の `d0/` 前提でパスを決め打ちしない）。`result-summary.json` は `autostart_orchestrator` が `output_dir / "result-summary.json"` と `run_dir / "result-summary.json"` の両方を探索する（ソース: `_refresh_latest_artifact_links`）。この探索ロジックを変更する場合は配置パターンと整合させること。** 守らないと `latest/` へのシンボリックリンクが張れず、最新成果物の特定手段が失われる。
 
 
-13. **評価パイプライン（`aichallenge-aws` の `main.bash`）は `EVAL_ENTRYPOINT` で指定された入口スクリプトを `bash /aichallenge/<EVAL_ENTRYPOINT>` で起動する。入口は `run_evaluation.bash`（s2r_1_practice_solo）、`run_safety_gate.bash`（s2r_2_practice_solo）、`run_parallel.bash`（s2r_1_rated_trios）の 3 本だけ。各入口は ROS overlay を自分で source し、`SIM_MODE` / `ROS_DOMAIN_ID` / `LOG_DIR` を自分で決める（`docker-entrypoint.sh` や compose の環境変数に依存しない）。評価環境側が渡すのは `EVAL_ENTRYPOINT` / `EVAL_TIMEOUT_SEC` / `RUN_RVIZ=false` と Batch 固有の env のみ。名前・引数なし起動・自己完結性を変更しない。** 守らないと評価イメージ（entrypoint 無し、提出物は `/aichallenge/d1` overlay）で `ros2: command not found` や提出パッケージ未検出で全件 failed になる（2026-09-02 に実際に発生）。
+13. **評価パイプライン（`aichallenge-aws` の `main.bash`）が起動する入口は §6 の 3 本（`run_evaluation.bash` / `run_safety_gate.bash` / `run_parallel.bash`）だけで、いずれも引数なし・自己完結（ROS overlay と `SIM_MODE` を自分で決める）。名前と自己完結性を変更しない。** 守らないと評価イメージ（entrypoint 無し、提出物は `/aichallenge/d1` overlay）で `ros2: command not found` や提出パッケージ未検出で全件 failed になる。
 ---
 
 ## 2. ドメイン規約の約束
@@ -227,22 +227,24 @@ AWS `result_update` Lambda は `vehicles[].vehicle_number` と `vehicles[].final
 | AWSIM 起動引数 | `simulator_scripts/<SIM_MODE>.sh` | 同じ（`run_simulator.bash` 経由） |
 | 完了シグナル | 人が `make down` | `/admin/awsim/state` の `terminate`（gate）/ `finishall`（parallel）を `main.bash` が監視し、grace 後にアップロード |
 
-この差を吸収する層が **評価環境の入口スクリプト** である。ローカル用スクリプト（`run_evaluation.bash` など）を評価環境から直接呼ばない。
+この差を吸収する層が **評価環境の入口スクリプト** である。`run_evaluation.bash` はローカルの `make eval` と評価環境の両方で使う唯一のスクリプトで、そのために ROS overlay を自分で source する。
 
 ### 6-1. 入口スクリプト
 
 `aichallenge-aws` の `start_build` Lambda が `evaluation_mode` を入口名とタイムアウトに変換し、Step Functions が Batch コンテナの env（`EVAL_ENTRYPOINT`, `EVAL_TIMEOUT_SEC`）として渡す。`main.bash` は許可リストで名前を検証してから起動する。
 
-| evaluation_mode | EVAL_ENTRYPOINT | 中で行うこと | EVAL_TIMEOUT_SEC |
+| evaluation_mode | EVAL_ENTRYPOINT | SIM_MODE（AWSIM 引数） | EVAL_TIMEOUT_SEC |
 |---|---|---|---|
-| `s2r_1_practice_solo` | `run_evaluation.bash` | base overlay を source → `/aichallenge/d1/workspace/install/setup.bash` があれば source → `SIM_MODE`（既定 `eval` = `eval.sh`）で `evaluation.launch.xml` | 800 |
-| `s2r_2_practice_solo` | `run_safety_gate.bash` | `SIM_MODE=safety-gate`、`ROS_DOMAIN_ID=1` を設定 → `exec bash run_evaluation.bash` | 400 |
-| `s2r_1_rated_trios` | `run_parallel.bash` | base overlay を source → `exec ros2 launch parallel.launch.xml log_dir:=/output/<ts>`（各車両の `d1..d3` overlay は launch 内で source） | 800 |
+| `s2r_1_practice_solo` | `run_evaluation.bash` | `eval`（`eval.sh`） | 800 |
+| `s2r_2_practice_solo` | `run_safety_gate.bash` → `run_evaluation.bash` | `safety-gate`（`safety-gate.sh`） | 400 |
+| `s2r_1_rated_trios` | `run_parallel.bash` → `parallel.launch.xml` | `parallel`（`parallel.sh`） | 800 |
+
+ソース確認先: 各入口スクリプト本体、`aichallenge-aws/cloudformation_templates/lambda_functions/_shared/evaluation_mode.py`（`EVAL_RUNTIME_PROFILES`）、`aichallenge-aws/makefile/main.bash`（`ALLOWED_ENTRYPOINTS`）。
 
 ### 6-2. 入口スクリプトが守ること
 
 - **引数なしで起動できる。** 評価環境から渡されるのは環境変数のみ（`EVAL_TIMEOUT_SEC` は `main.bash` の `timeout` に使われ、入口には渡らない）。
-- **ROS 環境を自分で整える。** `/aichallenge/workspace/install/setup.bash` を必ず source し、単体系は `d1` overlay が存在すれば source する（ローカル eval イメージでは存在しないので条件付き）。この処理は `run_evaluation.bash` に置き、`run_safety_gate.bash` はモード指定だけの薄い wrapper にする。
+- **ROS 環境を自分で整える。** 単体系は `run_evaluation.bash` が `d1` overlay（あれば。base workspace を chain する）か base workspace を source し、`run_safety_gate.bash` はモード指定だけの薄い wrapper。parallel は `run_parallel.bash` が base を、`parallel.launch.xml` が各車両の `dN` を source する。`LOG_DIR` は launch ファイルが `log_dir` から設定する。
 - **`SIM_MODE` を自分で決める。** 入口 = モードなので、外から渡された `SIM_MODE` は上書きする。AWSIM の引数は `simulator_scripts/<mode>.sh` に置き、入口や launch に直接書かない（`eval.sh` / `safety-gate.sh` / `parallel.sh`）。
 - **rviz は評価環境側が切る（`RUN_RVIZ=false` を `main.bash` が export）。** 録画は standalone の `aichallenge_screen_recorder`（X root window 全体 = 1280x720）で行う。rviz が居ると Autoware 標準の AutowareScreenCapturePanel が同じ `/debug/service/capture_screen` を提供し、rviz ウィンドウ領域（1850x1136、オフセット 70,27）しか録れない。`evaluation.launch.xml` は `run_rviz=false` かつ `capture=true` のときだけ recorder を起動する。debug 可視化 / motion analytics は `debug` 引数で独立に on。
 - **出力レイアウトは §5 に従う。** 単体系は `/output/<ts>/d1/`（`result-summary.json` も同じ場所）、parallel は `/output/<ts>/`（`result-summary.json` は run_dir 直下、車両ログは `d1..d3/`）。


### PR DESCRIPTION
## 概要

<img width="1222" height="815" alt="image" src="https://github.com/user-attachments/assets/14e0f0a7-6cb4-4f7c-abf0-f7900ebec396" />

評価環境(aichallenge-aws の Batch コンテナ)が起動する **入口スクリプトを 3 本に固定**し、その契約を `docs/interface/evaluation-interface.md` §6 として明文化する。AWSIM の起動引数は `simulator_scripts/<mode>.sh` に集約し、launch ファイルや入口には書かない。

| evaluation_mode | 入口(EVAL_ENTRYPOINT) | SIM_MODE / AWSIM 引数 |
|---|---|---|
| `s2r_1_practice_solo` | `run_evaluation.bash` | `eval` / `eval.sh` |
| `s2r_2_practice_solo` | `run_safety_gate.bash` → `run_evaluation.bash` | `safety-gate` / `safety-gate.sh` |
| `s2r_1_rated_trios` | `run_parallel.bash` → `parallel.launch.xml` | `parallel` / `parallel.sh` |

背景: dev 提出 1788312938488 が `ros2: command not found` で failed。評価イメージには ENTRYPOINT が無く、提出物は `/aichallenge/d1` overlay に置かれるため、ローカル(`docker-entrypoint.sh` が source する)と前提が異なる。この差を入口スクリプト側で吸収する。

## 変更点

### 入口スクリプト(`aichallenge/`)
- `run_evaluation.bash`: `/aichallenge/d1/workspace/install/setup.bash` があればそれを、無ければ base workspace を source してから `exec ros2 launch`。`run_rviz:=${RUN_RVIZ:-true}`、`debug:=true` を渡す。ローカル `make eval` と評価環境の両方で使う唯一のスクリプト
- `run_safety_gate.bash`(新規): `SIM_MODE=safety-gate` と `ROS_DOMAIN_ID` を決めて `run_evaluation.bash` を exec する薄い wrapper
- `run_parallel.bash`(新規、prd から移植): base を source して `parallel.launch.xml` を起動。各車両の `dN` overlay は launch 側で source

