### PR TITLE
feat(remote): add `make workspace` terminator layout and localhost test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 .PHONY: autoware-build autoware-vehicle autoware-simulator autoware-request-initialpose autoware-request-control  awsim-request-start awsim-request-reset autoware-driver-zenoh autoware-driver-zenoh-rosbag setup-vehicle \
-	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-attach autoware-bash eval e2e vehicle-tui
+	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-attach autoware-bash eval e2e vehicle-tui workspace
 
 # Used by docker-compose.yml for build/eval artifact ownership.
 HOST_UID ?= $(shell id -u)
@@ -170,3 +170,7 @@ download:
 # 再接続して同じターゲットを叩けば -A で同じセッションへアタッチする。
 vehicle-tui:
 	tmux new -A -s aic-vehicle "vehicle/tui.py"
+
+# 遠隔操作用ワークスペース。terminator を 4 分割 (車両 ssh×3 + remote/gui_tools.py) で開く。
+workspace:
+	remote/workspace.bash

--- a/remote/connect_ssh.bash
+++ b/remote/connect_ssh.bash
@@ -1,17 +1,20 @@
 #!/bin/bash
 
-# 1. 引数が2つ以上指定されているかチェック
-if [ $# -lt 2 ]; then
-    echo "エラー: 接続先とユーザー名を指定してください。"
-    echo "使用法: $0 [A2|A3|A6|A7] ユーザー名 [実行するコマンド]"
+# 1. 接続先が指定されているかチェック
+if [ $# -lt 1 ]; then
+    echo "エラー: 接続先を指定してください。"
+    echo "使用法: $0 [A2|A3|A6|A7|test] [ユーザー名] [実行するコマンド]"
+    echo "  ユーザー名を省略するとローカルのユーザー名 ($USER) で接続する"
+    echo "  test: 踏み台を通さず localhost:22 へ接続する (動作確認用)"
     exit 1
 fi
 
 TARGET_ID=$1
-USERNAME=$2
+USERNAME=${2:-$USER}
+HOST="zenoh.dev.aichallenge-board.jsae.or.jp"
 PORT=""
 
-# 2. 引数に応じてポート番号を設定
+# 2. 引数に応じて接続先ホストとポート番号を設定
 case "$TARGET_ID" in
 A2)
     PORT=10025
@@ -25,15 +28,20 @@ A6)
 A7)
     PORT=10022
     ;;
+test)
+    HOST="localhost"
+    PORT=22
+    ;;
 *)
     echo "エラー: 不明な接続先です: $TARGET_ID"
-    echo "利用可能な接続先: A2, A3, A6, A7"
+    echo "利用可能な接続先: A2, A3, A6, A7, test"
     exit 1
     ;;
 esac
 
-# 最初の2つの引数（接続先とユーザー名）を引数リストから削除
-shift 2
+# 接続先とユーザー名を引数リストから削除
+shift
+[ $# -gt 0 ] && shift
 
 # 3. 選択されたポートとユーザーでautosshを実行
 # 3番目以降の引数（現在は "$@" に格納されている）があれば、それがリモートコマンドとして実行される
@@ -48,5 +56,5 @@ fi
 autossh -AC -M 0 -p "$PORT" \
     -o ServerAliveInterval=60 \
     -o ServerAliveCountMax=3 \
-    "${USERNAME}@zenoh.dev.aichallenge-board.jsae.or.jp" \
+    "${USERNAME}@${HOST}" \
     "$@" # 3番目以降の引数をすべてコマンドとして渡す

--- a/remote/connect_ssh.bash
+++ b/remote/connect_ssh.bash
@@ -11,7 +11,7 @@ fi
 
 TARGET_ID=$1
 USERNAME=${2:-$USER}
-HOST="zenoh.dev.aichallenge-board.jsae.or.jp"
+host="zenoh.dev.aichallenge-board.jsae.or.jp"
 PORT=""
 
 # 2. 引数に応じて接続先ホストとポート番号を設定
@@ -29,7 +29,7 @@ A7)
     PORT=10022
     ;;
 test)
-    HOST="localhost"
+    host="localhost"
     PORT=22
     ;;
 *)
@@ -39,9 +39,8 @@ test)
     ;;
 esac
 
-# 接続先とユーザー名を引数リストから削除
-shift
-[ $# -gt 0 ] && shift
+# 接続先とユーザー名 (あれば) を引数リストから削除
+shift $(($# > 1 ? 2 : 1))
 
 # 3. 選択されたポートとユーザーでautosshを実行
 # 3番目以降の引数（現在は "$@" に格納されている）があれば、それがリモートコマンドとして実行される
@@ -56,5 +55,5 @@ fi
 autossh -AC -M 0 -p "$PORT" \
     -o ServerAliveInterval=60 \
     -o ServerAliveCountMax=3 \
-    "${USERNAME}@${HOST}" \
+    "${USERNAME}@${host}" \
     "$@" # 3番目以降の引数をすべてコマンドとして渡す

--- a/remote/connect_ssh.bash
+++ b/remote/connect_ssh.bash
@@ -3,14 +3,19 @@
 # 1. 接続先が指定されているかチェック
 if [ $# -lt 1 ]; then
     echo "エラー: 接続先を指定してください。"
-    echo "使用法: $0 [A2|A3|A6|A7|test] [ユーザー名] [実行するコマンド]"
+    echo "使用法: $0 [ユーザー名@]<A2|A3|A6|A7|test> [実行するコマンド]"
     echo "  ユーザー名を省略するとローカルのユーザー名 ($USER) で接続する"
     echo "  test: 踏み台を通さず localhost:22 へ接続する (動作確認用)"
     exit 1
 fi
 
+# 1番目の引数を ssh と同じ [ユーザー名@]接続先 として解釈する
+USERNAME=$USER
 TARGET_ID=$1
-USERNAME=${2:-$USER}
+if [[ $1 == *@* ]]; then
+    USERNAME=${1%@*}
+    TARGET_ID=${1#*@}
+fi
 host="zenoh.dev.aichallenge-board.jsae.or.jp"
 PORT=""
 
@@ -39,11 +44,11 @@ test)
     ;;
 esac
 
-# 接続先とユーザー名 (あれば) を引数リストから削除
-shift $(($# > 1 ? 2 : 1))
+# 接続先を引数リストから削除
+shift
 
 # 3. 選択されたポートとユーザーでautosshを実行
-# 3番目以降の引数（現在は "$@" に格納されている）があれば、それがリモートコマンドとして実行される
+# 2番目以降の引数（現在は "$@" に格納されている）があれば、それがリモートコマンドとして実行される
 if [ $# -gt 0 ]; then
     # コマンドが指定されている場合
     echo "Connecting to $TARGET_ID as $USERNAME to run command: '$*'"
@@ -56,4 +61,4 @@ autossh -AC -M 0 -p "$PORT" \
     -o ServerAliveInterval=60 \
     -o ServerAliveCountMax=3 \
     "${USERNAME}@${host}" \
-    "$@" # 3番目以降の引数をすべてコマンドとして渡す
+    "$@" # 2番目以降の引数をすべてコマンドとして渡す

--- a/remote/terminator.config
+++ b/remote/terminator.config
@@ -1,0 +1,51 @@
+# make workspace 用 terminator レイアウト (remote/workspace.bash から -g で読み込む)
+[global_config]
+[keybindings]
+[profiles]
+  [[default]]
+[layouts]
+  [[aic-workspace]]
+    [[[window0]]]
+      type = Window
+      parent = ""
+      fullscreen = True
+    [[[hpaned0]]]
+      type = HPaned
+      parent = window0
+      order = 0
+      ratio = 0.5
+    [[[vpaned0]]]
+      type = VPaned
+      parent = hpaned0
+      order = 0
+      ratio = 0.5
+    [[[vpaned1]]]
+      type = VPaned
+      parent = hpaned0
+      order = 1
+      ratio = 0.75
+    [[[terminal0]]]
+      type = Terminal
+      parent = vpaned0
+      order = 0
+      title = [車両PC] ssh 1/3 車両TUI
+      command = ./remote/workspace.bash pane tui
+    [[[terminal1]]]
+      type = Terminal
+      parent = vpaned0
+      order = 1
+      title = [車両PC] ssh 2/3 監視
+      command = ./remote/workspace.bash pane monitor
+    [[[terminal2]]]
+      type = Terminal
+      parent = vpaned1
+      order = 0
+      title = [車両PC] ssh 3/3 予備
+      command = ./remote/workspace.bash pane spare
+    [[[terminal3]]]
+      type = Terminal
+      parent = vpaned1
+      order = 1
+      title = [手元PC] GUI tools
+      command = ./remote/workspace.bash pane gui
+[plugins]

--- a/remote/terminator.config
+++ b/remote/terminator.config
@@ -1,14 +1,20 @@
-# make workspace 用 terminator レイアウト (remote/workspace.bash から -g で読み込む)
 [global_config]
 [keybindings]
 [profiles]
   [[default]]
 [layouts]
+  [[default]]
+    [[[window0]]]
+      type = Window
+      parent = ""
+    [[[child1]]]
+      type = Terminal
+      parent = window0
   [[aic-workspace]]
     [[[window0]]]
       type = Window
       parent = ""
-      fullscreen = True
+      maximised = True
     [[[hpaned0]]]
       type = HPaned
       parent = window0

--- a/remote/terminator.config
+++ b/remote/terminator.config
@@ -1,15 +1,5 @@
-[global_config]
-[keybindings]
-[profiles]
-  [[default]]
+# make workspace 用 terminator レイアウト (remote/workspace.bash が一時コピーを -g で読み込む)
 [layouts]
-  [[default]]
-    [[[window0]]]
-      type = Window
-      parent = ""
-    [[[child1]]]
-      type = Terminal
-      parent = window0
   [[aic-workspace]]
     [[[window0]]]
       type = Window
@@ -35,23 +25,22 @@
       parent = vpaned0
       order = 0
       title = [車両PC] ssh 1/3 車両TUI
-      command = ./remote/workspace.bash pane tui
+      command = ./remote/workspace.bash tui
     [[[terminal1]]]
       type = Terminal
       parent = vpaned0
       order = 1
       title = [車両PC] ssh 2/3 監視
-      command = ./remote/workspace.bash pane monitor
+      command = ./remote/workspace.bash monitor
     [[[terminal2]]]
       type = Terminal
       parent = vpaned1
       order = 0
       title = [車両PC] ssh 3/3 予備
-      command = ./remote/workspace.bash pane spare
+      command = ./remote/workspace.bash spare
     [[[terminal3]]]
       type = Terminal
       parent = vpaned1
       order = 1
       title = [手元PC] GUI tools
-      command = ./remote/workspace.bash pane gui
-[plugins]
+      command = ./remote/workspace.bash gui

--- a/remote/workspace.bash
+++ b/remote/workspace.bash
@@ -1,11 +1,8 @@
 #!/bin/bash
 # 遠隔操作用ワークスペース。terminator を 4 分割 (ssh×3 + GUI tools) で立ち上げる。
-#   workspace.bash              terminator を起動 (make workspace から呼ばれる)
-#   workspace.bash pane <role>  各ペイン内で実行され、ヒントを表示して bash に移る
+#   workspace.bash                          terminator を起動 (make workspace から呼ばれる)
+#   workspace.bash tui|monitor|spare|gui    各ペイン内で実行され、ヒントを表示して bash に移る
 set -euo pipefail
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 
 CONNECT="./remote/connect_ssh.bash <A2|A3|A6|A7|test>"
 
@@ -13,47 +10,49 @@ hint() {
     echo "================================================================"
     printf '%s\n' "$@"
     echo "================================================================"
+    # ペインは小さく生成された後に最大化で広がるため、bash の再描画が直前の行を潰す。
+    # その犠牲用に空行を 1 つ置く。
     echo
 }
 
-if [ $# -eq 0 ]; then
-    cd "${REPO_ROOT}"
+case "${1-}" in
+"")
+    cd "$(dirname "$0")/.."
+    # terminator は -g で渡したファイルを終了時に書き戻すので、リポジトリのファイルは直接渡さない。
     # -u: 既存 terminator への DBus 委譲を避ける (委譲先は自分の config しか見ずレイアウトが無視される)
-    exec terminator -u -g remote/terminator.config -l aic-workspace
-fi
-
-if [ "$1" != "pane" ] || [ $# -ne 2 ]; then
-    echo "Usage: $0 [pane tui|monitor|spare|gui]" >&2
-    exit 1
-fi
-
-case "$2" in
+    cfg=$(mktemp)
+    trap 'rm -f "$cfg"' EXIT
+    cp remote/terminator.config "$cfg"
+    terminator -u -g "$cfg" -l aic-workspace
+    ;;
 tui)
     hint "[ssh 1/3] 車両 TUI" \
         "  ${CONNECT}" \
         "  接続後、車両側で: cd aichallenge-racingkart && make vehicle-tui"
+    exec bash
     ;;
 monitor)
     hint "[ssh 2/3] 監視用" \
         "  ${CONNECT}" \
         "  接続後、車両側で: cd aichallenge-racingkart && make autoware-bash" \
         "  (autoware コンテナ内の bash が開く。ros2 topic echo / ros2 node list などで状態を見る)"
+    exec bash
     ;;
 spare)
     hint "[ssh 3/3] 予備" \
         "  ${CONNECT}" \
         "  自由に使うシェル"
+    exec bash
     ;;
 gui)
     hint "[GUI tools] remote/gui_tools.py を起動中" \
         "  zenoh / RViz / joy はこの GUI から操作する" \
         "  GUI を閉じるとこのシェルに戻る"
     ./remote/gui_tools.py || true
+    exec bash
     ;;
 *)
-    echo "Unknown pane role: $2" >&2
+    echo "Usage: $0 [tui|monitor|spare|gui]" >&2
     exit 1
     ;;
 esac
-
-exec bash

--- a/remote/workspace.bash
+++ b/remote/workspace.bash
@@ -1,0 +1,59 @@
+#!/bin/bash
+# 遠隔操作用ワークスペース。terminator を 4 分割 (ssh×3 + GUI tools) で立ち上げる。
+#   workspace.bash              terminator を起動 (make workspace から呼ばれる)
+#   workspace.bash pane <role>  各ペイン内で実行され、ヒントを表示して bash に移る
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+CONNECT="./remote/connect_ssh.bash <A2|A3|A6|A7|test>"
+
+hint() {
+    echo "================================================================"
+    printf '%s\n' "$@"
+    echo "================================================================"
+    echo
+}
+
+if [ $# -eq 0 ]; then
+    cd "${REPO_ROOT}"
+    # -u: 既存 terminator への DBus 委譲を避ける (委譲先は自分の config しか見ずレイアウトが無視される)
+    exec terminator -u -g remote/terminator.config -l aic-workspace
+fi
+
+if [ "$1" != "pane" ] || [ $# -ne 2 ]; then
+    echo "Usage: $0 [pane tui|monitor|spare|gui]" >&2
+    exit 1
+fi
+
+case "$2" in
+tui)
+    hint "[ssh 1/3] 車両 TUI" \
+        "  ${CONNECT}" \
+        "  接続後、車両側で: cd aichallenge-racingkart && make vehicle-tui"
+    ;;
+monitor)
+    hint "[ssh 2/3] 監視用" \
+        "  ${CONNECT}" \
+        "  接続後、車両側で: cd aichallenge-racingkart && make autoware-bash" \
+        "  (autoware コンテナ内の bash が開く。ros2 topic echo / ros2 node list などで状態を見る)"
+    ;;
+spare)
+    hint "[ssh 3/3] 予備" \
+        "  ${CONNECT}" \
+        "  自由に使うシェル"
+    ;;
+gui)
+    hint "[GUI tools] remote/gui_tools.py を起動中" \
+        "  zenoh / RViz / joy はこの GUI から操作する" \
+        "  GUI を閉じるとこのシェルに戻る"
+    ./remote/gui_tools.py || true
+    ;;
+*)
+    echo "Unknown pane role: $2" >&2
+    exit 1
+    ;;
+esac
+
+exec bash

--- a/remote/workspace.bash
+++ b/remote/workspace.bash
@@ -4,7 +4,7 @@
 #   workspace.bash tui|monitor|spare|gui    各ペイン内で実行され、ヒントを表示して bash に移る
 set -euo pipefail
 
-CONNECT="./remote/connect_ssh.bash <A2|A3|A6|A7|test>"
+CONNECT="./remote/connect_ssh.bash [ユーザー名@]<A2|A3|A6|A7|test>"
 
 hint() {
     echo "================================================================"


### PR DESCRIPTION
## 概要

遠隔車両操作用のワークスペースを `make workspace` で立ち上げられるようにします。

## 変更点

- `make workspace`: terminator を全画面・4分割で起動する（`remote/workspace.bash` + `remote/terminator.config`）
  - `[車両PC] ssh 1/3 車両TUI`: 接続後 `make vehicle-tui` の案内
  - `[車両PC] ssh 2/3 監視`: 接続後 `make autoware-bash` の案内
  - `[車両PC] ssh 3/3 予備`: 自由に使う ssh シェル
  - `[手元PC] GUI tools`（高さ1/4）: `remote/gui_tools.py` を自動起動
  - ssh ペインはヒントを表示してシェルで待つだけで、接続は手動
  - 既存 terminator への DBus 委譲でレイアウトが無視されないよう `-u` で独立起動
- `remote/connect_ssh.bash`
  - `test` ターゲットを追加（踏み台を通さず localhost:22 へ接続）
  - ユーザー名を省略可にし、省略時は `$USER` を使う

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/9859cbf8-49d7-4c86-a228-93055cd0d8d2" />


## 確認

- `make workspace` を実機で起動し、4分割・タイトル・ヒント・GUI 自動起動を目視確認
- `connect_ssh.bash test` / `A2 <user> <cmd>` の引数組み立てを確認
- pre-commit（shellcheck / shfmt）通過

