### PR TITLE
docs(vehicle): update manual joy namespace

### DIFF
--- a/vehicle/setup_check.md
+++ b/vehicle/setup_check.md
@@ -461,7 +461,7 @@ ros2 topic echo /sensing/gnss/navpvt
 ```bash
 # システム起動後の確認
 ros2 topic echo /racing_kart/vcu/status
-ros2 run joy joy_node --ros-args -r __ns:=/racing_kart
+ros2 run joy joy_node --ros-args -r __ns:=/racing_kart/sd
 ```
 
 ### ログ・記録確認


### PR DESCRIPTION
## 概要
車両の手動確認手順で、Joy入力を現在のSD用トピックへpublishするように修正します。

## 関連Issue
- PR #305のレビュー指摘: https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/305#discussion_r3956271957

## 変更内容
- [x] `joy_node` のnamespaceを `/racing_kart/sd` に更新

## テスト方法
- [x] `git diff --check`
- [x] `pre-commit run --files vehicle/setup_check.md`

## スクリーンショット
ドキュメントのみの変更のためありません。