### PR TITLE
fix(remote): snapshot processes before stop all

### DIFF
--- a/remote/gui_tools.py
+++ b/remote/gui_tools.py
@@ -1054,7 +1054,13 @@ class RemoteGui:
         プロセスが立ち上がってしまう。
         """
         self._cancel_pending_launches()
-        for log_key in [key for key in self.processes if self._process_running(key)]:
+        # リーダースレッドが終了したプロセスを削除しても、走査中の辞書が変化しない
+        # ようにロック中にスナップショットを取る。
+        with self._processes_lock:
+            entries = list(self.processes.items())
+        for log_key, entry in entries:
+            if entry.process.poll() is not None:
+                continue
             self._append_log(log_key, "[stop all requested]\n")
             self._stop_process(log_key)
         self._refresh_button_states()


### PR DESCRIPTION
## 概要
Stop All処理中にリーダースレッドがプロセス辞書を更新すると、辞書走査が失敗する競合を防ぎます。

## 関連Issue
- PR #305のレビュー指摘: https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/305#discussion_r3956271948

## 変更内容
- [x] `_processes_lock` 保持中に管理対象プロセスのスナップショットを取得
- [x] スナップショットを使って稼働中プロセスを停止

## テスト方法
- [x] `python3 -m py_compile remote/gui_tools.py`
- [x] `pre-commit run --files remote/gui_tools.py`

## スクリーンショット
UI表示の変更はありません。