### PR TITLE
feat(remote): default gui_tools vehicle id from repo .env VEHICLE_ID

### DIFF
--- a/remote/gui_tools.py
+++ b/remote/gui_tools.py
@@ -17,8 +17,32 @@ from tkinter.scrolledtext import ScrolledText
 ROOT_DIR = Path(__file__).resolve().parent
 REMOTE_DIR = ROOT_DIR
 
-DEFAULT_VEHICLE_ID = "A2"
+# リポジトリ直下の .env (車両 PC と同じ書式)。VEHICLE_ID があればそれを接続先の初期値にする。
+ENV_FILE = ROOT_DIR.parent / ".env"
+DEFAULT_VEHICLE_ID = "A2"  # .env に VEHICLE_ID が無い場合のフォールバック
 DEFAULT_USERNAME = ""  # Deprecated: SSH User input removed.
+
+
+def read_env_vehicle_id(env_file: Path) -> Optional[str]:
+    """Return VEHICLE_ID from a dotenv-style file, or None if absent/blank."""
+    try:
+        lines = env_file.read_text().splitlines()
+    except OSError:
+        return None
+    value: Optional[str] = None
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw = line.split("=", 1)
+        if key.strip() != "VEHICLE_ID":
+            continue
+        value = raw.strip().strip("\"'").strip() or None
+    return value
+
+
+def default_vehicle_id(env_file: Path = ENV_FILE) -> str:
+    return read_env_vehicle_id(env_file) or DEFAULT_VEHICLE_ID
 
 
 # --- Devias Material Kit Pro: Chateau Green palette (approx) ---
@@ -359,7 +383,7 @@ class RemoteGui:
             )
             raise SystemExit(1)
 
-        self.vehicle_id_var = tk.StringVar(value=DEFAULT_VEHICLE_ID)
+        self.vehicle_id_var = tk.StringVar(value=default_vehicle_id())
         # SSH user was removed from UI; keep empty string for compatibility.
 
         self.processes: Dict[str, subprocess.Popen[str]] = {}

--- a/remote/tests/gui_tools_test.py
+++ b/remote/tests/gui_tools_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Unit tests for remote/gui_tools.py (.env parsing only, no Tk).
+
+Run with python3 -m unittest (no third-party runner).
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from gui_tools import DEFAULT_VEHICLE_ID, default_vehicle_id, read_env_vehicle_id  # noqa: E402
+
+
+def _write_env(text: str) -> Path:
+    path = Path(tempfile.mkdtemp()) / ".env"
+    path.write_text(text)
+    return path
+
+
+class TestReadEnvVehicleId(unittest.TestCase):
+    def test_reads_plain_value(self):
+        self.assertEqual(read_env_vehicle_id(_write_env("VEHICLE_ID=A3\n")), "A3")
+
+    def test_strips_quotes_and_spaces(self):
+        self.assertEqual(read_env_vehicle_id(_write_env('VEHICLE_ID = "A6" \n')), "A6")
+
+    def test_ignores_comments_and_other_keys(self):
+        text = "# VEHICLE_ID=A1\nV2X_VEHICLE_ID=d1\nROS_DOMAIN_ID=1\n"
+        self.assertIsNone(read_env_vehicle_id(_write_env(text)))
+
+    def test_blank_value_is_none(self):
+        self.assertIsNone(read_env_vehicle_id(_write_env("VEHICLE_ID=\n")))
+
+    def test_missing_file_is_none(self):
+        self.assertIsNone(read_env_vehicle_id(Path(tempfile.mkdtemp()) / ".env"))
+
+    def test_last_assignment_wins(self):
+        self.assertEqual(read_env_vehicle_id(_write_env("VEHICLE_ID=A1\nVEHICLE_ID=A2\n")), "A2")
+
+
+class TestDefaultVehicleId(unittest.TestCase):
+    def test_uses_env_value(self):
+        self.assertEqual(default_vehicle_id(_write_env("VEHICLE_ID=A7\n")), "A7")
+
+    def test_falls_back_when_missing(self):
+        self.assertEqual(default_vehicle_id(Path(tempfile.mkdtemp()) / ".env"), DEFAULT_VEHICLE_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

`remote/gui_tools.py` の Vehicle ID 入力欄の初期値を、リポジトリ直下 `.env` の `VEHICLE_ID` から取るようにしました。車両 PC と同じ `.env` を置いておけば、ソースを編集せずに接続先がペアの車両に揃います。

## 変更内容

- `<repo>/.env` の `VEHICLE_ID=...` 行を解析し、起動時の Vehicle ID 既定値に使用
  - コメント行・他キー (`V2X_VEHICLE_ID` など) は無視、引用符と空白は除去、同キー複数時は最後を採用
- `.env` が無い、またはキーが空の場合は従来どおり `A2` にフォールバック
- 入力欄は引き続き手入力で上書き可能
- `remote/tests/gui_tools_test.py` に `unittest` ベースのテストを追加 (8 件)

## 検証

- `python3 -m unittest remote/tests/gui_tools_test.py` → 8 件成功
- `pre-commit run --files remote/gui_tools.py remote/tests/gui_tools_test.py` → 通過
- 一時的に `VEHICLE_ID=A3` の `.env` を置いて起動時既定値が `A3` になること、`.env` 無しで `A2` になることを確認

## 補足

値の妥当性検証は入れていません。`.env.example` のまま `VEHICLE_ID=A0` だと既定値は `A0` になり、接続時に `connect_zenoh.bash` 側で従来どおりエラーになります。
