### PR TITLE
fix(mpc): store runtime v_max parameter in m/s like the startup value

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/mpc_controller.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/mpc_controller.py
@@ -263,9 +263,12 @@ class MPCController(Node):
 
             for param in parameters:
                 if param.name == "v_max" and param.type_ == Parameter.Type.DOUBLE:
-                    mpc_cfg.v_max = param.value
-                    self._mpc.update_v_max(kmh_to_m_per_sec(param.value))
-                    v_ref: List[float] = [kmh_to_m_per_sec(param.value)] * len(self._reference_path.waypoints)
+                    # The parameter is km/h (as in config.yaml) but MPCConfig.v_max is m/s
+                    # everywhere else, e.g. the per-tick ref_vel cap in _control().
+                    # パラメータは km/h、MPCConfig.v_max は m/s で保持する。
+                    mpc_cfg.v_max = kmh_to_m_per_sec(param.value)
+                    self._mpc.update_v_max(mpc_cfg.v_max)
+                    v_ref: List[float] = [mpc_cfg.v_max] * len(self._reference_path.waypoints)
                     self._reference_path.set_v_ref(v_ref)
 
                     self.get_logger().warn(f"v_max was updated to '{param.value}' [km/h]")

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the ROS-free test helpers (mpc_fixture, ros_stubs) importable.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/ros_stubs.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/ros_stubs.py
@@ -1,0 +1,163 @@
+"""Minimal stand-ins for rclpy and the ROS message packages.
+
+Lets node modules (``mpc_controller``, ``path_constraints_provider``) be
+imported and partially exercised by pytest on a host without a ROS 2
+installation.  Only what those modules touch at import / construction time is
+provided; anything else resolves to a permissive dummy.
+"""
+import os
+import sys
+import types
+
+
+class _Dummy:
+    """Accepts any constructor arguments / attribute access / call."""
+
+    def __init__(self, *args, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __call__(self, *args, **kwargs):
+        return _Dummy()
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return _Dummy()
+
+
+class _DummyModule(types.ModuleType):
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return type(name, (_Dummy,), {})
+
+
+class _Logger:
+    def __init__(self):
+        self.messages = []
+
+    def _log(self, msg, *args, **kwargs):
+        self.messages.append(str(msg))
+
+    info = warn = warning = error = debug = _log
+
+
+class Node:
+    """Records subscriptions / parameter callbacks instead of talking to DDS."""
+
+    def __init__(self, name, *args, **kwargs):
+        self._stub_name = name
+        self._stub_logger = _Logger()
+        self._stub_params = {}
+        self._stub_param_callbacks = []
+        self._stub_subscriptions = []
+        self._stub_publishers = []
+
+    def get_logger(self):
+        if not hasattr(self, "_stub_logger"):
+            self._stub_logger = _Logger()
+        return self._stub_logger
+
+    def declare_parameter(self, name, value=None, *args, **kwargs):
+        if not hasattr(self, "_stub_params"):
+            self._stub_params = {}
+        self._stub_params[name] = value
+        return _Dummy(name=name, value=value)
+
+    def get_parameter(self, name):
+        value = getattr(self, "_stub_params", {}).get(name, False)
+        return _Dummy(get_parameter_value=lambda: _Dummy(bool_value=bool(value)))
+
+    def set_parameters(self, params):
+        return []
+
+    def add_on_set_parameters_callback(self, cb):
+        if not hasattr(self, "_stub_param_callbacks"):
+            self._stub_param_callbacks = []
+        self._stub_param_callbacks.append(cb)
+
+    def create_subscription(self, msg_type, topic, callback, qos, *args, **kwargs):
+        if not hasattr(self, "_stub_subscriptions"):
+            self._stub_subscriptions = []
+        self._stub_subscriptions.append((topic, callback))
+        return _Dummy()
+
+    def create_publisher(self, msg_type, topic, qos, *args, **kwargs):
+        if not hasattr(self, "_stub_publishers"):
+            self._stub_publishers = []
+        self._stub_publishers.append(topic)
+        return _Dummy()
+
+    def create_timer(self, *args, **kwargs):
+        return _Dummy()
+
+    def create_rate(self, *args, **kwargs):
+        return _Dummy()
+
+    def get_clock(self):
+        return _Dummy()
+
+    def destroy_node(self):
+        pass
+
+
+class Parameter:
+    class Type:
+        NOT_SET = 0
+        BOOL = 1
+        INTEGER = 2
+        DOUBLE = 3
+        STRING = 4
+
+    def __init__(self, name, type_=None, value=None):
+        self.name = name
+        self.type_ = type_
+        self.value = value
+
+
+class SetParametersResult:
+    def __init__(self, successful=True, reason=""):
+        self.successful = successful
+        self.reason = reason
+
+
+class _QoSEnum:
+    RELIABLE = BEST_EFFORT = SYSTEM_DEFAULT = "qos"
+    TRANSIENT_LOCAL = VOLATILE = "qos"
+    KEEP_LAST = KEEP_ALL = "qos"
+
+
+def install(package_share_dir):
+    """Register the stub modules.  ``package_share_dir`` is what
+    ``get_package_share_directory('multi_purpose_mpc_ros')`` returns."""
+    names = [
+        "rclpy", "rclpy.node", "rclpy.parameter", "rclpy.qos", "rclpy.time",
+        "rclpy.impl", "rclpy.impl.rcutils_logger", "rclpy.executors",
+        "rclpy.signals", "rclpy.utilities",
+        "ament_index_python", "ament_index_python.packages",
+        "visualization_msgs", "visualization_msgs.msg",
+        "std_msgs", "std_msgs.msg", "nav_msgs", "nav_msgs.msg",
+        "geometry_msgs", "geometry_msgs.msg",
+        "rcl_interfaces", "rcl_interfaces.msg",
+        "autoware_auto_control_msgs", "autoware_auto_control_msgs.msg",
+        "autoware_auto_planning_msgs", "autoware_auto_planning_msgs.msg",
+        "v2x_msgs", "v2x_msgs.msg",
+        "multi_purpose_mpc_ros_msgs", "multi_purpose_mpc_ros_msgs.msg",
+    ]
+    for name in names:
+        sys.modules[name] = _DummyModule(name)
+    sys.modules["rclpy.node"].Node = Node
+    sys.modules["rclpy.parameter"].Parameter = Parameter
+    sys.modules["rcl_interfaces.msg"].SetParametersResult = SetParametersResult
+    qos = sys.modules["rclpy.qos"]
+    qos.QoSProfile = _Dummy
+    qos.QoSDurabilityPolicy = qos.QoSReliabilityPolicy = _QoSEnum
+    qos.QoSHistoryPolicy = _QoSEnum
+    sys.modules["rclpy"].ok = lambda: False
+    share = os.path.abspath(package_share_dir)
+    sys.modules["ament_index_python.packages"].get_package_share_directory = (
+        lambda _pkg: share)
+    for parent, child in [("rclpy", "node"), ("rclpy", "parameter"),
+                          ("rclpy", "qos"), ("rclpy", "time")]:
+        setattr(sys.modules[parent], child, sys.modules[f"{parent}.{child}"])

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_controller_params.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_controller_params.py
@@ -1,0 +1,85 @@
+"""The ``v_max`` runtime parameter is in km/h; ``MPCConfig.v_max`` is m/s.
+
+At start-up ``MPCConfig.v_max = kmh_to_m_per_sec(cfg.mpc.v_max)``, but the
+parameter callback stored the raw km/h value.  ``_control()`` then clamps every
+tick with ``min(kmh_to_m_per_sec(ref_vel), self._mpc_cfg.v_max)``
+(mpc_controller.py:812), so after ``ros2 param set /mpc_controller v_max 10.0``
+the cap became 10 m/s (36 km/h) and the kart ran at the 30 km/h ref_vel
+instead of 10 km/h: lowering v_max made it faster.
+"""
+import os
+
+import pytest
+import yaml
+from scipy import sparse
+
+import ros_stubs
+
+PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ros_stubs.install(PKG_DIR)
+
+from multi_purpose_mpc_ros import mpc_controller as mc  # noqa: E402
+from multi_purpose_mpc_ros.common import convert_to_namedtuple  # noqa: E402
+from multi_purpose_mpc_ros.core.utils import kmh_to_m_per_sec  # noqa: E402
+
+
+class _FakeMPC:
+    v_max = None
+
+    def update_v_max(self, v):
+        self.v_max = v
+
+
+class _FakeRefPath:
+    def __init__(self, n=5):
+        self.waypoints = [object()] * n
+        self.v_ref = None
+
+    def set_v_ref(self, v_ref):
+        self.v_ref = list(v_ref)
+
+
+def _controller():
+    with open(os.path.join(PKG_DIR, "config", "config.yaml")) as f:
+        cfg = convert_to_namedtuple(yaml.safe_load(f))
+    ctrl = mc.MPCController.__new__(mc.MPCController)
+    ros_stubs.Node.__init__(ctrl, "mpc_controller")
+    m = cfg.mpc
+    ctrl._cfg = cfg
+    ctrl._mpc_cfg = mc.MPCConfig(
+        m.N, sparse.diags(m.Q), sparse.diags(m.R), sparse.diags(m.QN),
+        kmh_to_m_per_sec(m.v_max), m.a_min, m.a_max, m.ay_max, 0.5,
+        m.steer_rate_max, m.control_rate, m.steering_tire_angle_gain_var,
+        m.accel_low_pass_gain, m.steer_low_pass_gain, m.wp_id_offset,
+        m.use_max_kappa_pred)
+    ctrl._mpc = _FakeMPC()
+    ctrl._reference_path = _FakeRefPath()
+    ctrl._setup_parameters_callback()
+    return ctrl, ctrl._stub_param_callbacks[-1]
+
+
+def _set(cb, name, value):
+    P = ros_stubs.Parameter
+    return cb([P(name, P.Type.DOUBLE, value)])
+
+
+def test_startup_value_is_m_per_s():
+    ctrl, _ = _controller()
+    assert ctrl._mpc_cfg.v_max == pytest.approx(20.0 / 3.6)
+
+
+def test_runtime_v_max_is_stored_in_the_same_unit_as_at_startup():
+    ctrl, cb = _controller()
+    _set(cb, "v_max", 10.0)
+    assert ctrl._mpc_cfg.v_max == pytest.approx(10.0 / 3.6)
+    assert ctrl._mpc.v_max == pytest.approx(10.0 / 3.6)
+    assert ctrl._reference_path.v_ref == [pytest.approx(10.0 / 3.6)] * 5
+
+
+def test_lowering_v_max_lowers_the_per_tick_ref_vel_cap():
+    ctrl, cb = _controller()
+    _set(cb, "v_max", 10.0)
+    ref_vel_kmph_section = 30.0              # config/ref_vel.yaml, most sections
+    # the per-tick clamp in MPCController._control (mpc_controller.py:812)
+    cap = min(kmh_to_m_per_sec(ref_vel_kmph_section), ctrl._mpc_cfg.v_max)
+    assert cap == pytest.approx(10.0 / 3.6)   # 10 km/h, not 30 km/h


### PR DESCRIPTION
## 概要
`mpc_controller` の `v_max` パラメータ（km/h）を実行中に変更すると、m/s で扱われている `MPCConfig.v_max` に km/h の値がそのまま入る問題を修正します。

## 症状
`ros2 param set /mpc_controller v_max 10.0` のあと、毎周期の上限 `min(kmh_to_m_per_sec(ref_vel), self._mpc_cfg.v_max)`（812 行）が 10 m/s（36 km/h）と比較されます。その結果、ref_vel の 30 km/h で走ります。**v_max を下げると速くなります**（起動時の上限 20 km/h より速い）。実機で速度上限として使う場合に危険です。

## 修正
起動時（384 行）と同じく m/s に変換して保存します。ログは従来どおり km/h で表示します。

## テスト
`test/test_mpc_controller_params.py`（rclpy をスタブ化し、実際のパラメータコールバックを実行）
- 修正前: 2 件失敗
- 修正後: `test/` 全体で 17 件パス

#252 と隣接行が変わるため、どちらかが先に入ったら rebase します。

## Summary
Setting the `v_max` parameter (km/h) at runtime stored the km/h value into `MPCConfig.v_max`, which is m/s everywhere else.

## Symptom
After `ros2 param set /mpc_controller v_max 10.0`, the per-tick cap `min(kmh_to_m_per_sec(ref_vel), self._mpc_cfg.v_max)` (line 812) compares against 10 m/s (36 km/h), so the kart runs at the 30 km/h ref_vel. **Lowering v_max makes it faster** than the 20 km/h start-up cap, which is dangerous when v_max is used as a speed limit on the real kart.

## Fix
Convert to m/s, as at start-up (line 384). The log message stays in km/h.

## Test
`test/test_mpc_controller_params.py` (rclpy stubbed; the real parameter callback runs)
- before: 2 failures
- after: 17 passed across `test/`

```
before: FAILED test_runtime_v_max_is_stored_in_the_same_unit_as_at_startup
        FAILED test_lowering_v_max_lowers_the_per_tick_ref_vel_cap
after:  17 passed
```

This touches the line next to #252's change; whichever lands second needs a trivial rebase.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
