### PR TITLE
fix(mpc): search closest waypoint in a window around the previous match

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/spatial_bicycle_models.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/spatial_bicycle_models.py
@@ -144,6 +144,17 @@ class SpatialBicycleModel(ABC):
         # Set initial waypoint ID
         self.wp_id = 0
 
+        # Windowed closest-waypoint search: look only at [-back, +ahead] waypoints
+        # around the previous match, and fall back to the whole path when nothing in
+        # the window is within relocalize_distance (first call, reset, teleport).
+        # A whole-path argmin jumps to another leg where the course folds back
+        # (kashiwanoha: antiparallel legs 2.96 m apart). ahead <= 0 disables it.
+        # 折り返し区間で別の区間に飛ばないよう、前回位置の近傍窓で探索する。
+        self.closest_wp_window_back = 5
+        self.closest_wp_window_ahead = 30
+        self.relocalize_distance = 5.0
+        self._last_closest_wp_id = None
+
         # Set initial waypoint
         self.current_waypoint = self.reference_path.waypoints[self.wp_id]
 
@@ -297,12 +308,30 @@ class SpatialBicycleModel(ABC):
         :param y: y coordinate
         :return: Index of the closest waypoint
         """
+        waypoints = self.reference_path.waypoints
+        n_wp = len(waypoints)
+        prev = self._last_closest_wp_id
+        if prev is not None and self.closest_wp_window_ahead > 0 and prev < n_wp:
+            ids = np.arange(prev - self.closest_wp_window_back,
+                            prev + self.closest_wp_window_ahead + 1)
+            if self.reference_path.circular:
+                ids = np.mod(ids, n_wp)
+            else:
+                ids = ids[(ids >= 0) & (ids < n_wp)]
+            d = np.hypot(np.array([waypoints[i].x for i in ids]) - x,
+                         np.array([waypoints[i].y for i in ids]) - y)
+            k = int(np.argmin(d))
+            if d[k] <= self.relocalize_distance:
+                self._last_closest_wp_id = int(ids[k])
+                return self._last_closest_wp_id
+
         # Compute distances from the point to all waypoints
-        distances = np.sqrt((np.array([wp.x for wp in self.reference_path.waypoints]) - x)**2 +
-                            (np.array([wp.y for wp in self.reference_path.waypoints]) - y)**2)
+        distances = np.sqrt((np.array([wp.x for wp in waypoints]) - x)**2 +
+                            (np.array([wp.y for wp in waypoints]) - y)**2)
 
         # Get the index of the closest waypoint
         closest_wp_id = np.argmin(distances)
+        self._last_closest_wp_id = int(closest_wp_id)
 
         return closest_wp_id
 
@@ -393,6 +422,7 @@ class BicycleModel(SpatialBicycleModel):
     def update_reference_path(self, reference_path):
         # Update Reference Path
         self.reference_path = reference_path
+        self._last_closest_wp_id = None  # indices of the old path are meaningless
 
         # Update the current waypoint based on the new reference path
         self.wp_id = self.get_closest_waypoint(self.temporal_state.x, self.temporal_state.y)

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the ROS-free test helpers (mpc_fixture, ros_stubs) importable.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_closest_waypoint_window.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_closest_waypoint_window.py
@@ -1,0 +1,105 @@
+"""BicycleModel.update_states must not re-localise onto another leg of the course.
+
+``get_closest_waypoint`` took the argmin over the whole path every cycle.  On
+the kashiwanoha preset the legs at s~146-167 m and s~277-298 m run
+antiparallel ~3 m apart, so a 1.5 m lateral error made wp_id (and with it s,
+the reference velocity and the MPC horizon) jump ~135 waypoints to the
+opposite leg.  See ISSUE-06 / Zenn tamasy "MPC制御をやってみた" section 5.
+"""
+import math
+import os
+
+import numpy as np
+import pytest
+
+from multi_purpose_mpc_ros.core.map import Map
+from multi_purpose_mpc_ros.core.reference_path import ReferencePath
+from multi_purpose_mpc_ros.core.spatial_bicycle_models import BicycleModel
+from multi_purpose_mpc_ros.core.utils import load_ref_path
+
+PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OFFSET = 1.5  # m, well inside GNSS/tracking error on a real kart
+
+
+def _model(track):
+    env = os.path.join(PKG_DIR, "env", track)
+    track_map = Map(os.path.join(env, "occupancy_grid_map.yaml"))
+    x, y, _, _ = load_ref_path(os.path.join(env, "traj_mincurv.csv"))
+    ref = ReferencePath(track_map, x, y, 0.6, 2, 6.0, True)
+    return BicycleModel(ref, 1.087, 2.30, 1.0 / 40.0)
+
+
+def _xy(model):
+    wps = model.reference_path.waypoints
+    return np.array([w.x for w in wps]), np.array([w.y for w in wps])
+
+
+def _global_argmin(model, x, y):
+    X, Y = _xy(model)
+    return int(np.argmin(np.hypot(X - x, Y - y)))
+
+
+def _circ(a, b, n):
+    d = abs(a - b) % n
+    return min(d, n - d)
+
+
+def _offset(wp, d):
+    return wp.x - d * math.sin(wp.psi), wp.y + d * math.cos(wp.psi)
+
+
+def _fold_back_case(model):
+    """First waypoint whose OFFSET-m lateral pose is matched, by a whole-path
+    argmin, to a waypoint more than 20 waypoints away."""
+    wps = model.reference_path.waypoints
+    n = len(wps)
+    for k, wp in enumerate(wps):
+        for side in (1.0, -1.0):
+            px, py = _offset(wp, side * OFFSET)
+            j = _global_argmin(model, px, py)
+            if _circ(j, k, n) > 20:
+                return k, wp, px, py, j
+    pytest.fail(f"no fold-back jump at {OFFSET} m on kashiwanoha (geometry changed?)")
+
+
+@pytest.fixture(scope="module")
+def kashiwa():
+    return _model("kashiwanoha")
+
+
+def test_fold_back_geometry_exists(kashiwa):
+    k, _, _, _, j = _fold_back_case(kashiwa)
+    assert _circ(j, k, len(kashiwa.reference_path.waypoints)) > 100
+
+
+def test_lateral_error_does_not_jump_to_the_other_leg():
+    model = _model("kashiwanoha")
+    k, wp, px, py, j = _fold_back_case(model)
+    model.update_states(wp.x, wp.y, wp.psi)              # on the line
+    model.update_states(px, py, wp.psi)                  # OFFSET m to the side
+    n = len(model.reference_path.waypoints)
+    assert _circ(model.wp_id, k, n) <= 5, f"jumped from wp {k} to wp {model.wp_id}"
+
+
+def test_first_call_and_teleport_use_the_whole_path():
+    model = _model("kashiwanoha")
+    wps = model.reference_path.waypoints
+    a, b = wps[40], wps[240]
+    model.update_states(a.x, a.y, a.psi)
+    assert model.wp_id == _global_argmin(model, a.x, a.y)
+    model.update_states(b.x, b.y, b.psi)                 # far outside the window
+    assert model.wp_id == _global_argmin(model, b.x, b.y)
+
+
+def test_same_location_as_whole_path_on_the_default_track():
+    """No behaviour change on citycircuit (final_ver3). The circular path
+    repeats its closing point, so compare locations, not indices."""
+    model = _model("final_ver3")
+    wps = model.reference_path.waypoints
+    for i in range(0, len(wps), 3):
+        for off in (0.0, 1.0, -1.0):
+            x, y = _offset(wps[i], off)
+            model.update_states(x, y, wps[i].psi)
+            g = wps[_global_argmin(model, x, y)]
+            got = wps[model.wp_id]
+            assert math.hypot(got.x - g.x, got.y - g.y) < 1e-9


### PR DESCRIPTION
## 概要
Fixes #313

`BicycleModel.get_closest_waypoint()` が毎周期「全経路の argmin」で自己位置を再割り当てするため、コースが折り返す場所では少しの横ずれで逆方向の区間に飛ぶ問題を修正します。

## 症状
kashiwanoha プリセットでは、横ずれ 1.5 m で wp 152 が wp 287（135 waypoint 先の逆向き区間）に割り当てられます。s、参照速度、MPC 予測区間がすべて別区間のものになります。

## 修正
- 前回の一致点の周辺 `[-5, +30]` だけを探索する（周回は wrap）
- 窓内の最短距離が `relocalize_distance`（5 m）を超えたとき（初回・リセット・テレポート）だけ全経路探索にフォールバックする
- `update_reference_path()` で記憶をリセットする
- `closest_wp_window_ahead = 0` で従来の全経路探索に戻せる
- 1 回あたりの探索点数は 36 点（従来は約 350-380 点）

## テスト
`test/test_closest_waypoint_window.py`（実際の kashiwanoha / final_ver3 地図・経路）
- 修正前: `AssertionError: jumped from wp 152 to wp 287`
- 修正後: `test/` 全体で 18 件パス。final_ver3 では全経路探索と同じ位置を返すことも確認

#252 も `get_closest_waypoint` を変更しているため、どちらかが先に入ったら rebase します。参考: 参加者記事 Zenn tamasy さん §5 でも同じ現象が報告されています。

## Summary
Fixes #313

`BicycleModel.get_closest_waypoint()` re-localised with a whole-path argmin every cycle, so where the course folds back a small lateral error snaps the car onto the opposite leg.

## Symptom
On the kashiwanoha preset a 1.5 m lateral error maps wp 152 to wp 287, the antiparallel leg 135 waypoints away. `s`, the reference velocity and the MPC horizon then all come from that leg.

## Fix
- Search `[-5, +30]` around the previous match, wrapping on circular paths.
- Fall back to the whole path when nothing in the window is within `relocalize_distance` (5 m): first call, reset, teleport.
- Reset the memory in `update_reference_path()`.
- `closest_wp_window_ahead = 0` restores the old whole-path search.
- 36 points per call instead of about 350-380.

## Test
`test/test_closest_waypoint_window.py`, on the real kashiwanoha and final_ver3 maps and paths
- before: `AssertionError: jumped from wp 152 to wp 287`
- after: 18 passed across `test/`; on final_ver3 it returns the same location as the whole-path search

#252 also changes `get_closest_waypoint`; whichever lands second will be rebased. Same failure reported by a participant: Zenn, tamasy, §5.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
