### PR TITLE
fix(mpc): path_constraints_provider passes MPC flags by keyword

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/path_constraints_provider.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/path_constraints_provider.py
@@ -197,8 +197,12 @@ class PathConstraintsProvider(Node):
                 state_constraints,
                 input_constraints,
                 mpc_cfg.ay_max,
-                True,
-                True)
+                # keyword arguments: MPC.__init__ gained max_steering_rate and
+                # wp_id_offset before these flags, so positional True, True failed
+                max_steering_rate=cfg_mpc.steer_rate_max / cfg_mpc.steering_tire_angle_gain_var,
+                wp_id_offset=cfg_mpc.wp_id_offset,
+                use_obstacle_avoidance=True,
+                use_path_constraints_topic=True)
             return mpc_cfg, mpc
 
         def compute_speed_profile(car: BicycleModel, mpc_config: MPCConfig) -> None:

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the ROS-free test helpers (mpc_fixture, ros_stubs) importable.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/ros_stubs.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/ros_stubs.py
@@ -1,0 +1,163 @@
+"""Minimal stand-ins for rclpy and the ROS message packages.
+
+Lets node modules (``mpc_controller``, ``path_constraints_provider``) be
+imported and partially exercised by pytest on a host without a ROS 2
+installation.  Only what those modules touch at import / construction time is
+provided; anything else resolves to a permissive dummy.
+"""
+import os
+import sys
+import types
+
+
+class _Dummy:
+    """Accepts any constructor arguments / attribute access / call."""
+
+    def __init__(self, *args, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __call__(self, *args, **kwargs):
+        return _Dummy()
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return _Dummy()
+
+
+class _DummyModule(types.ModuleType):
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return type(name, (_Dummy,), {})
+
+
+class _Logger:
+    def __init__(self):
+        self.messages = []
+
+    def _log(self, msg, *args, **kwargs):
+        self.messages.append(str(msg))
+
+    info = warn = warning = error = debug = _log
+
+
+class Node:
+    """Records subscriptions / parameter callbacks instead of talking to DDS."""
+
+    def __init__(self, name, *args, **kwargs):
+        self._stub_name = name
+        self._stub_logger = _Logger()
+        self._stub_params = {}
+        self._stub_param_callbacks = []
+        self._stub_subscriptions = []
+        self._stub_publishers = []
+
+    def get_logger(self):
+        if not hasattr(self, "_stub_logger"):
+            self._stub_logger = _Logger()
+        return self._stub_logger
+
+    def declare_parameter(self, name, value=None, *args, **kwargs):
+        if not hasattr(self, "_stub_params"):
+            self._stub_params = {}
+        self._stub_params[name] = value
+        return _Dummy(name=name, value=value)
+
+    def get_parameter(self, name):
+        value = getattr(self, "_stub_params", {}).get(name, False)
+        return _Dummy(get_parameter_value=lambda: _Dummy(bool_value=bool(value)))
+
+    def set_parameters(self, params):
+        return []
+
+    def add_on_set_parameters_callback(self, cb):
+        if not hasattr(self, "_stub_param_callbacks"):
+            self._stub_param_callbacks = []
+        self._stub_param_callbacks.append(cb)
+
+    def create_subscription(self, msg_type, topic, callback, qos, *args, **kwargs):
+        if not hasattr(self, "_stub_subscriptions"):
+            self._stub_subscriptions = []
+        self._stub_subscriptions.append((topic, callback))
+        return _Dummy()
+
+    def create_publisher(self, msg_type, topic, qos, *args, **kwargs):
+        if not hasattr(self, "_stub_publishers"):
+            self._stub_publishers = []
+        self._stub_publishers.append(topic)
+        return _Dummy()
+
+    def create_timer(self, *args, **kwargs):
+        return _Dummy()
+
+    def create_rate(self, *args, **kwargs):
+        return _Dummy()
+
+    def get_clock(self):
+        return _Dummy()
+
+    def destroy_node(self):
+        pass
+
+
+class Parameter:
+    class Type:
+        NOT_SET = 0
+        BOOL = 1
+        INTEGER = 2
+        DOUBLE = 3
+        STRING = 4
+
+    def __init__(self, name, type_=None, value=None):
+        self.name = name
+        self.type_ = type_
+        self.value = value
+
+
+class SetParametersResult:
+    def __init__(self, successful=True, reason=""):
+        self.successful = successful
+        self.reason = reason
+
+
+class _QoSEnum:
+    RELIABLE = BEST_EFFORT = SYSTEM_DEFAULT = "qos"
+    TRANSIENT_LOCAL = VOLATILE = "qos"
+    KEEP_LAST = KEEP_ALL = "qos"
+
+
+def install(package_share_dir):
+    """Register the stub modules.  ``package_share_dir`` is what
+    ``get_package_share_directory('multi_purpose_mpc_ros')`` returns."""
+    names = [
+        "rclpy", "rclpy.node", "rclpy.parameter", "rclpy.qos", "rclpy.time",
+        "rclpy.impl", "rclpy.impl.rcutils_logger", "rclpy.executors",
+        "rclpy.signals", "rclpy.utilities",
+        "ament_index_python", "ament_index_python.packages",
+        "visualization_msgs", "visualization_msgs.msg",
+        "std_msgs", "std_msgs.msg", "nav_msgs", "nav_msgs.msg",
+        "geometry_msgs", "geometry_msgs.msg",
+        "rcl_interfaces", "rcl_interfaces.msg",
+        "autoware_auto_control_msgs", "autoware_auto_control_msgs.msg",
+        "autoware_auto_planning_msgs", "autoware_auto_planning_msgs.msg",
+        "v2x_msgs", "v2x_msgs.msg",
+        "multi_purpose_mpc_ros_msgs", "multi_purpose_mpc_ros_msgs.msg",
+    ]
+    for name in names:
+        sys.modules[name] = _DummyModule(name)
+    sys.modules["rclpy.node"].Node = Node
+    sys.modules["rclpy.parameter"].Parameter = Parameter
+    sys.modules["rcl_interfaces.msg"].SetParametersResult = SetParametersResult
+    qos = sys.modules["rclpy.qos"]
+    qos.QoSProfile = _Dummy
+    qos.QoSDurabilityPolicy = qos.QoSReliabilityPolicy = _QoSEnum
+    qos.QoSHistoryPolicy = _QoSEnum
+    sys.modules["rclpy"].ok = lambda: False
+    share = os.path.abspath(package_share_dir)
+    sys.modules["ament_index_python.packages"].get_package_share_directory = (
+        lambda _pkg: share)
+    for parent, child in [("rclpy", "node"), ("rclpy", "parameter"),
+                          ("rclpy", "qos"), ("rclpy", "time")]:
+        setattr(sys.modules[parent], child, sys.modules[f"{parent}.{child}"])

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_path_constraints_provider.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_path_constraints_provider.py
@@ -1,0 +1,33 @@
+"""path_constraints_provider must be constructible.
+
+MPC.__init__ gained ``max_steering_rate`` and ``wp_id_offset`` before
+``use_obstacle_avoidance`` / ``use_path_constraints_topic``, but the provider
+still passed ten positional arguments ending in ``True, True``: construction
+raised ``TypeError: missing 2 required positional arguments``, so the node died
+at start-up every time it was launched (mpc_controller.launch.py with
+use_obstacle_avoidance:=true).
+"""
+import os
+
+import ros_stubs
+
+PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ros_stubs.install(PKG_DIR)
+
+from multi_purpose_mpc_ros.core.MPC import MPC  # noqa: E402
+from multi_purpose_mpc_ros.path_constraints_provider import (  # noqa: E402
+    PathConstraintsProvider,
+)
+
+CONFIG = os.path.join(PKG_DIR, "config", "config.yaml")
+
+
+def test_provider_constructs_with_the_shipped_config():
+    node = PathConstraintsProvider(CONFIG)
+    assert isinstance(node._mpc, MPC)
+    # the two trailing ``True`` flags now land on the parameters they meant
+    assert node._mpc.use_obstacle_avoidance is True
+    assert node._mpc.use_path_constraints_topic is True
+    assert not isinstance(node._mpc.max_steering_rate, bool)
+    assert not isinstance(node._mpc.wp_id_offset, bool)
+    assert "/aichallenge/objects" in [t for t, _ in node._stub_subscriptions]


### PR DESCRIPTION
## 概要
`path_constraints_provider` が起動時に必ず `TypeError` で落ちる問題を修正します。`docs/spec/mpc-integration.md` の「さらに高度な回避」で案内され、`mpc_controller.launch.py use_obstacle_avoidance:=true` で起動されるノードです（既定の `mpc.launch.xml` には含まれません）。

## 原因
`MPC.__init__` に `max_steering_rate` と `wp_id_offset` が追加されたとき（`core/MPC.py:15-16`）、provider 側（`path_constraints_provider.py:191-201`）は位置引数 `True, True` のまま残っていました。そのため `True, True` が別の引数に入り、必須引数が 2 つ不足しています。

## 修正
キーワード引数で渡します。`max_steering_rate` / `wp_id_offset` は `mpc_controller` と同じ値（`steer_rate_max / steering_tire_angle_gain_var`、`wp_id_offset`）にします。provider はこの MPC で求解しないため、値は整合していれば十分です。

## テスト
`test/test_path_constraints_provider.py`（同梱の config.yaml・final_ver3 地図で実ノードを構築。rclpy はスタブ）
- 修正前: `TypeError: MPC.__init__() missing 2 required positional arguments: 'use_obstacle_avoidance' and 'use_path_constraints_topic'`
- 修正後: `test/` 全体で 15 件パス

テスト用ヘルパー（`test/conftest.py`, `test/ros_stubs.py`）は #312 と同一内容です。先に入った方に合わせて rebase します。

## Summary
`path_constraints_provider` always died at start-up with a `TypeError`. It is the node documented under "さらに高度な回避" in `docs/spec/mpc-integration.md` and started by `mpc_controller.launch.py use_obstacle_avoidance:=true` (it is not in the default `mpc.launch.xml`).

## Cause
When `max_steering_rate` and `wp_id_offset` were added to `MPC.__init__` (`core/MPC.py:15-16`), the provider (`path_constraints_provider.py:191-201`) kept its positional `True, True`, so the flags landed on the wrong parameters and two required arguments were missing.

## Fix
Pass the flags by keyword, and pass `max_steering_rate` / `wp_id_offset` as `mpc_controller` does. The provider never solves with this MPC object, so the values only need to be consistent.

## Test
`test/test_path_constraints_provider.py` builds the real node with the shipped config.yaml and final_ver3 map (rclpy stubbed).
- before: `TypeError: MPC.__init__() missing 2 required positional arguments`
- after: 15 passed across `test/`

The test helpers (`test/conftest.py`, `test/ros_stubs.py`) are identical to the ones in #312; whichever lands second will be rebased.

Not covered: the node's runtime behaviour after start-up (0.5 Hz full-lap constraint recomputation) has not been run in AWSIM.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
