### PR TITLE
fix(vehicle): never extract a leftover tarball in download_submission.sh

### DIFF
--- a/vehicle/download_submission.py
+++ b/vehicle/download_submission.py
@@ -294,9 +294,10 @@ class SubmissionLister:
             if data.get('comment'):
                 logger.info(f"Comment: {data['comment']}")
 
-            # Create download directory inside vehicle folder
-            script_dir = os.path.dirname(os.path.abspath(__file__))
-            download_dir = os.path.join(script_dir, 'download')
+            # Save into the caller-provided download directory (e.g. a per-invocation
+            # temp directory), so concurrent invocations and leftover archives from a
+            # prior interrupted run cannot be mixed up.
+            download_dir = os.path.abspath(output_dir)
             os.makedirs(download_dir, exist_ok=True)
 
             # Download the file using the pre-signed URL to download folder
@@ -383,9 +384,10 @@ class SubmissionLister:
             if data.get('comment'):
                 logger.info(f"Comment: {data['comment']}")
 
-            # Create download directory inside vehicle folder
-            script_dir = os.path.dirname(os.path.abspath(__file__))
-            download_dir = os.path.join(script_dir, 'download')
+            # Save into the caller-provided download directory (e.g. a per-invocation
+            # temp directory), so concurrent invocations and leftover archives from a
+            # prior interrupted run cannot be mixed up.
+            download_dir = os.path.abspath(output_dir)
             os.makedirs(download_dir, exist_ok=True)
 
             # Download the file using the pre-signed URL to download folder

--- a/vehicle/download_submission.sh
+++ b/vehicle/download_submission.sh
@@ -202,11 +202,13 @@ main() {
         print_info "  Submission ID: $SUBMISSION_ID"
     fi
 
-    # download_submission.py saves into $DOWNLOAD_DIR, and the tarball is only deleted after a
-    # successful extraction. Remove leftovers of interrupted runs first, so the extraction below
-    # can only pick the tarball downloaded by THIS run (find | head -1 is in directory order).
-    DOWNLOAD_DIR="$SCRIPT_DIR/download"
-    rm -f "$DOWNLOAD_DIR"/*.tar.gz
+    # Give this invocation its own download directory under vehicle/download, so a
+    # leftover tarball from an interrupted prior run, or a tarball from a concurrent
+    # invocation, can never be picked up here (find | head -1 previously raced on a
+    # single shared directory). Nothing about a prior run's archive is touched.
+    DOWNLOAD_BASE_DIR="$SCRIPT_DIR/download"
+    mkdir -p "$DOWNLOAD_BASE_DIR"
+    DOWNLOAD_DIR=$(mktemp -d "$DOWNLOAD_BASE_DIR/tmp.XXXXXXXX")
 
     # Run the Python script
     if [ -n "$SUBMISSION_ID" ]; then
@@ -218,7 +220,7 @@ main() {
     API_BASE_URL="$API_BASE_URL" python3 "$PYTHON_SCRIPT" \
         --username "$USERNAME" \
         --password "$PASSWORD" \
-        --output "$OUTPUT_DIR" \
+        --output "$DOWNLOAD_DIR" \
         ${SUBMISSION_ID:+--submission-id "$SUBMISSION_ID"} \
         ${USER_ID:+--user-id "$USER_ID"} \
         $VERBOSE
@@ -229,12 +231,14 @@ main() {
         print_success "Script completed successfully!"
     else
         print_error "Script failed with exit code: $exit_code"
+        # Nothing usable landed in this invocation's own temp directory; remove it
+        # without touching any other invocation's archive.
+        rmdir "${DOWNLOAD_DIR:?}" 2>/dev/null || true
         exit $exit_code
     fi
 
-    # Extract downloaded tar.gz file from download folder to the output directory
-    DOWNLOAD_DIR="$SCRIPT_DIR/download"
-    TAR_FILE=$(find "$DOWNLOAD_DIR" -name "*.tar.gz" -type f | head -1)
+    # Extract the tarball this invocation downloaded (and only this one).
+    TAR_FILE=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name "*.tar.gz" -type f | head -1)
 
     if [ -z "$TAR_FILE" ]; then
         print_error "No tar.gz file found in download directory: $DOWNLOAD_DIR"
@@ -253,9 +257,11 @@ main() {
     if tar -xzf "$TAR_FILE" -C "$OUTPUT_DIR"; then
         print_success "Extraction completed successfully!"
 
-        # Clean up the original tar.gz file
+        # Clean up this invocation's tar.gz and its now-empty temp directory. Other
+        # invocations' directories and archives are untouched.
         print_info "Cleaning up original tar.gz file..."
         rm -f "$TAR_FILE"
+        rmdir "${DOWNLOAD_DIR:?}" 2>/dev/null || true
         print_success "Cleanup completed successfully!"
     else
         print_error "Extraction failed!"

--- a/vehicle/download_submission.sh
+++ b/vehicle/download_submission.sh
@@ -202,6 +202,12 @@ main() {
         print_info "  Submission ID: $SUBMISSION_ID"
     fi
 
+    # download_submission.py saves into $DOWNLOAD_DIR, and the tarball is only deleted after a
+    # successful extraction. Remove leftovers of interrupted runs first, so the extraction below
+    # can only pick the tarball downloaded by THIS run (find | head -1 is in directory order).
+    DOWNLOAD_DIR="$SCRIPT_DIR/download"
+    rm -f "$DOWNLOAD_DIR"/*.tar.gz
+
     # Run the Python script
     if [ -n "$SUBMISSION_ID" ]; then
         print_info "Downloading submission by ID..."


### PR DESCRIPTION
`vehicle/download_submission.sh` は `find vehicle/download -name "*.tar.gz" | head -1` で展開する tar を選びます。以前の実行が展開前に中断されて tar が残っていると、今回ダウンロードしたものではなく残っていた tar（別チームの提出物の可能性あり）を展開し、「Extraction completed successfully!」と表示します。tar は展開成功時にしか削除されません（`:250-253`）。
ダウンロード前に `vehicle/download/*.tar.gz` を削除し、今回の tar だけが候補になるようにしました。
確認: 残骸 tar + 新規 tar の 3 通りの並びで、修正前は 2/3 で残骸を展開、修正後は 3/3 で要求した提出物を展開。

`vehicle/download_submission.sh` picks the tarball to extract with `find vehicle/download -name "*.tar.gz" | head -1`. If an earlier run stopped before extraction, its tarball is still there, and whichever file comes first in directory order is extracted. That can be another team's submission, and the script still prints "Extraction completed successfully!". Tarballs are deleted only after a successful extraction (`:250-253`).
This PR clears `vehicle/download/*.tar.gz` before downloading, so only this run's tarball can be picked.
Tested with one leftover plus one new tarball in three name orderings. Before: the leftover was extracted in 2 of 3. After: the requested submission was extracted in 3 of 3.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
