### PR TITLE
fix(make): bound the AWSIM start wait in make eval and show why it failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,11 @@ autoware-request-control:
 	CMD="ros2 topic pub -1 /awsim/control_mode_request_topic std_msgs/msg/Bool '{data: true}'" docker compose run --rm --no-deps autoware-command
 
 # awsim admin service use ROS_DOMAIN_ID 0
+# `ros2 topic pub -1` waits for a subscriber with no upper bound. Bound it so a dead AWSIM
+# (e.g. eval container exited) fails instead of hanging. AWSIM_START_TIMEOUT=0 waits forever.
+AWSIM_START_TIMEOUT ?= 300
 awsim-request-start:
-	CMD="env ROS_DOMAIN_ID=0 ros2 topic pub -1 /admin/awsim/start std_msgs/msg/Bool '{data: true}'" docker compose run --rm --no-deps autoware-command
+	CMD="env ROS_DOMAIN_ID=0 timeout $(AWSIM_START_TIMEOUT) ros2 topic pub -1 /admin/awsim/start std_msgs/msg/Bool '{data: true}'" docker compose run --rm --no-deps autoware-command
 
 awsim-request-reset:
 	CMD="env ROS_DOMAIN_ID=0 ros2 topic pub -1 /admin/awsim/reset std_msgs/msg/Empty '{}'" docker compose run --rm --no-deps autoware-command
@@ -97,7 +100,12 @@ gate%:
 eval:
 	@echo "Start evaluation simulation (AWSIM + Autoware)"
 	docker compose up -d autoware-simulator-evaluation
-	$(MAKE) awsim-request-start
+	@$(MAKE) awsim-request-start || { \
+		echo "[eval] AWSIM did not subscribe to /admin/awsim/start within $(AWSIM_START_TIMEOUT)s." >&2; \
+		echo "[eval] Evaluation container status and last log lines:" >&2; \
+		docker compose ps -a autoware-simulator-evaluation >&2; \
+		docker compose logs --tail 30 autoware-simulator-evaluation >&2; \
+		exit 1; }
 	@echo "To stop: make down  (docker compose down --remove-orphans)"
 
 # remote operation (docker compose up -d rviz2)

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,8 @@ eval:
 	@echo "Start evaluation simulation (AWSIM + Autoware)"
 	docker compose up -d autoware-simulator-evaluation
 	@$(MAKE) awsim-request-start || { \
-		echo "[eval] AWSIM did not subscribe to /admin/awsim/start within $(AWSIM_START_TIMEOUT)s." >&2; \
+		echo "[eval] AWSIM start request failed." >&2; \
+		echo "[eval] Configured AWSIM_START_TIMEOUT=$(AWSIM_START_TIMEOUT)s." >&2; \
 		echo "[eval] Evaluation container status and last log lines:" >&2; \
 		docker compose ps -a autoware-simulator-evaluation >&2; \
 		docker compose logs --tail 30 autoware-simulator-evaluation >&2; \


### PR DESCRIPTION
評価コンテナが起動直後に落ちると（提出物の install/ が空、AWSIM バイナリ未配置、launch 失敗など）、`make eval` は `awsim-request-start` の `ros2 topic pub -1` が購読者を無期限に待ち続け、`Waiting for at least 1 matching subscription(s)...` を出したまま止まります。Humble の `-1` は `--wait-matching-subscriptions 1` を上限なしで意味します。
`AWSIM_START_TIMEOUT`（既定 300 秒、0 で従来どおり無期限）で待ち時間に上限を設け、失敗時は評価コンテナの状態と最後の 30 行のログを表示して終了コード 1 で終わるようにしました。`awsim_state_manager` 自身が start を送るため（`admin_start_enabled: true`）、正常系の挙動は変わりません。
確認: 起動後すぐ exit 127 する代替 eval イメージで、修正前は 75 秒で強制終了するまで待機（Waiting 71 行）、修正後は 22 秒で原因（`run_evaluation.bash: No such file or directory`）を表示して終了。

If the evaluation container dies at start-up (a submission whose install/ is empty, a missing AWSIM binary, a crashing launch), `make eval` waits forever in `awsim-request-start`. In Humble, `ros2 topic pub -1` implies `--wait-matching-subscriptions 1` with no upper bound, so the terminal shows `Waiting for at least 1 matching subscription(s)...` indefinitely.
This PR bounds the wait with `AWSIM_START_TIMEOUT` (default 300 s; 0 keeps the old unbounded wait). On failure it prints the eval container's status and last 30 log lines, then exits 1. `awsim_state_manager` already sends the start trigger itself (`admin_start_enabled: true`), so a healthy run is unaffected.
Tested with a stand-in eval image (`ros:humble-ros-core` tagged as both `aichallenge-2025-dev` and `aichallenge-2025-eval`, no `/aichallenge` baked in, so it exits 127 right after starting) against the real dev Makefile and docker-compose.yml. Before (unpatched): `timeout 75 make eval` ran until the outer timeout killed it, exit=124, with 71 "Waiting for at least 1 matching subscription(s)..." lines. After (patched): `timeout 75 make eval AWSIM_START_TIMEOUT=20` exited after 22 s with exit=2 and printed the real cause, `bash: line 1: /aichallenge/run_evaluation.bash: No such file or directory`.

Risks: #300 (open, not yet merged as of this writing) adds an `eval-gate:` target right after `eval:`, and its hunk uses the old `$(MAKE) awsim-request-start` line as context. Whichever of these two PRs lands second will need a trivial rebase against the other.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
