### PR TITLE
fix(setup): drop newgrp that opens a nested shell in bootstrap

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -417,7 +417,6 @@ ensure_docker_group() {
     log "${INFO} Adding ${USER-} to docker group"
     sudo_refresh
     sudo usermod -aG docker "${USER-}"
-    newgrp docker
     warn "${WARN} Docker group takes effect after re-login."
     if [ "${SETUP_ASSUME_YES}" = "1" ]; then
         warn "${INFO} Non-interactive mode: continuing, but docker commands may fail until re-login."


### PR DESCRIPTION
#297 で `ensure_docker_group` に `newgrp docker` が追加されましたが、`newgrp` は新しいシェルを起動するだけで、実行中のスクリプト自身のグループは変わりません。そのため `./setup.bash bootstrap` を端末で実行すると、docker グループ追加の直後に対話シェルのプロンプトで止まったように見えます。`curl ... | bash` の場合は、新しいシェルがパイプ上の残りのスクリプトを読み込んで実行してしまいます。

`newgrp docker` の行を削除し、#297 以前の「再ログイン(または自分の端末で `newgrp docker`)してから再実行」の案内に戻しました。`--yes` 時は従来どおり `sudo docker` にフォールバックします。

確認: `ubuntu:22.04` 上で dev の実際の `ensure_docker_group` (setup.bash:411-429) を、`sudo` のみスタブして pty (`script(1)`, 4 秒タイムアウト) 付きで実行しました。修正前は `newgrp docker` が入れ子の対話シェルを起動し、そのプロンプトで停止して `timeout` が exit=124 を返しました。修正後は同じ手順で警告とヒントの行を表示して exit=0 で正常終了することを確認しました。`bash -n`、`shellcheck 0.11.0`、`shfmt -d -s -i 4`、および `pre-commit run --files setup.bash` はすべてクリーンです。cc @sasakisasaki

#297 added `newgrp docker` to `ensure_docker_group`. `newgrp` only starts a new shell; it never changes the group of the running script. As a result, `./setup.bash bootstrap` in a terminal appears to stop at an interactive prompt right after the docker-group step. With `curl ... | bash`, the new shell reads and executes the rest of the piped script itself.

This PR removes the line and restores the pre-#297 flow: re-login (or run `newgrp docker` in your own terminal), then re-run. In `--yes` mode the script still falls back to `sudo docker`.

Tested by running dev's real `ensure_docker_group` (setup.bash:411-429) in `ubuntu:22.04`, with only `sudo` stubbed, under a pty (`script(1)`, 4 s timeout). Before the fix: `newgrp docker` spawned a nested interactive shell, the driver got stuck at that prompt, and `timeout` reported exit=124. After the fix: the same harness prints the warn/info hint lines and exits 0. `bash -n`, `shellcheck 0.11.0`, `shfmt -d -s -i 4`, and `pre-commit run --files setup.bash` are all clean. cc @sasakisasaki

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
