### PR TITLE
fix(utils): report actuation/AWSIM check failures in topic_check.sh

### DIFF
--- a/aichallenge/utils/topic_check.sh
+++ b/aichallenge/utils/topic_check.sh
@@ -296,15 +296,16 @@ main() {
     # actuation_cmd の内容チェック
     echo ""
     echo "[INFO] actuation_cmd 内容チェック（accel_cmd > 0 かつ brake_cmd = 0.0）"
-    actuation_result=$(check_actuation_cmd) || true
-    actuation_rc=$?
+    # `|| true` would reset $? to 0, so capture the status in the fallback branch instead.
+    actuation_rc=0
+    actuation_result=$(check_actuation_cmd) || actuation_rc=$?
     printf '%-50s %s\n' "/control/command/actuation_cmd" "$actuation_result"
 
     # awsim トピックチェック
     echo ""
     echo "[INFO] AWSIM トピックチェック（実車環境確認）"
-    awsim_result=$(check_awsim_topics) || true
-    awsim_rc=$?
+    awsim_rc=0
+    awsim_result=$(check_awsim_topics) || awsim_rc=$?
     printf '%-50s %s\n' "AWSIM topics absence" "$awsim_result"
     echo ""
     echo "===== SUMMARY ====="


### PR DESCRIPTION
`aichallenge/utils/topic_check.sh` の actuation_cmd チェックと AWSIM トピック不在チェックは、`result=$(check) || true` の直後に `rc=$?` を読んでいるため、`$?` が常に `true` の 0 になり、詳細行が FAIL でも SUMMARY は PASS、終了コードも 0 になっていました（`:299-300`, `:306-307`）。
`rc=0; result=$(check) || rc=$?` に変更し、失敗時に SUMMARY が FAIL、終了コードが 4（actuation）/ 5（AWSIM）になるようにしました。
確認: ブレーキ中・AWSIM トピックありの偽 `ros2` で実行 → 修正前 exit=0 / PASS・PASS、修正後 exit=5 / FAIL・FAIL。shellcheck・shfmt・bash -n・pre-commit 通過。

The actuation_cmd check and the AWSIM-topics-absent check in `aichallenge/utils/topic_check.sh` read `rc=$?` right after `result=$(check) || true`. `$?` is therefore always the 0 of `true`: the detail line says FAIL, but the SUMMARY says PASS and the script exits 0 (`:299-300`, `:306-307`).
This PR captures the status in the fallback branch (`rc=0; result=$(check) || rc=$?`). A failing check now shows FAIL in the SUMMARY and exits 4 (actuation) or 5 (AWSIM), as the existing exit-code block intends.
Tested with a fake `ros2` (kart braking, an AWSIM topic present) in a `ubuntu:22.04` Docker container. Before: exit=0, PASS/PASS. After: exit=5, FAIL/FAIL. shellcheck 0.11.0, shfmt -d -s -i 4, bash -n, and `pre-commit run` are all clean.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
