### PR TITLE
feat(docker): warn when the eval submission tarball is older than the source

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -48,6 +48,24 @@ LOG_FILE="output/docker/${ts}-docker_build-$$.log"
 mkdir -p output/docker output/latest
 ln -sfn "${PWD}/${LOG_FILE}" output/latest/docker_build.log
 
+# The default tarball is only as fresh as the last ./create_submit_file.bash run. Warn when the
+# source tree has changed since, so an eval build does not silently test an old submission.
+# AIC_STRICT_SUBMIT=1 turns the warning into an error.
+DEFAULT_SUBMIT_TAR="submit/aichallenge_submit.tar.gz"
+SUBMIT_SRC_DIR="aichallenge/workspace/src/aichallenge_submit"
+if [ "$target" = "eval" ] && [ "${SUBMIT_TAR:-${DEFAULT_SUBMIT_TAR}}" = "${DEFAULT_SUBMIT_TAR}" ] &&
+    [ -f "${DEFAULT_SUBMIT_TAR}" ] && [ -d "${SUBMIT_SRC_DIR}" ]; then
+    newer_file="$(find "${SUBMIT_SRC_DIR}" -type f -newer "${DEFAULT_SUBMIT_TAR}" -not -path '*/__pycache__/*' -print -quit)"
+    if [ -n "${newer_file}" ]; then
+        echo "[WARN] ${DEFAULT_SUBMIT_TAR} is older than ${newer_file}" >&2
+        echo "[WARN] The eval image will contain the submission as it was when the tarball was made." >&2
+        echo "[WARN] Run ./create_submit_file.bash first to evaluate your current code." >&2
+        if [ "${AIC_STRICT_SUBMIT:-0}" = "1" ]; then
+            exit 1
+        fi
+    fi
+fi
+
 BUILD_ARGS=()
 if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     if [ ! -f "${SUBMIT_TAR}" ]; then

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -49,15 +49,31 @@ mkdir -p output/docker output/latest
 ln -sfn "${PWD}/${LOG_FILE}" output/latest/docker_build.log
 
 # The default tarball is only as fresh as the last ./create_submit_file.bash run. Warn when the
-# source tree has changed since, so an eval build does not silently test an old submission.
+# source tree has changed since (a newer file, or a file that was packed but has since been
+# deleted), so an eval build does not silently test an old submission. Comparing file lists also
+# catches a plain deletion, which leaves no newer file behind for the mtime check above to find.
 # AIC_STRICT_SUBMIT=1 turns the warning into an error.
 DEFAULT_SUBMIT_TAR="submit/aichallenge_submit.tar.gz"
 SUBMIT_SRC_DIR="aichallenge/workspace/src/aichallenge_submit"
 if [ "$target" = "eval" ] && [ "${SUBMIT_TAR:-${DEFAULT_SUBMIT_TAR}}" = "${DEFAULT_SUBMIT_TAR}" ] &&
     [ -f "${DEFAULT_SUBMIT_TAR}" ] && [ -d "${SUBMIT_SRC_DIR}" ]; then
     newer_file="$(find "${SUBMIT_SRC_DIR}" -type f -newer "${DEFAULT_SUBMIT_TAR}" -not -path '*/__pycache__/*' -print -quit)"
-    if [ -n "${newer_file}" ]; then
-        echo "[WARN] ${DEFAULT_SUBMIT_TAR} is older than ${newer_file}" >&2
+
+    # Files the tarball has but the current tree no longer does (deletions since packing).
+    tar_files="$(tar -tzf "${DEFAULT_SUBMIT_TAR}" 2>/dev/null | grep -v '/$' | sort -u || true)"
+    src_files="$(
+        cd "$(dirname "${SUBMIT_SRC_DIR}")" || exit 1
+        find "$(basename "${SUBMIT_SRC_DIR}")" -type f -not -path '*/__pycache__/*' -not -name '*.pyc' | sort -u
+    )"
+    deleted_file="$(comm -23 <(printf '%s\n' "${tar_files}") <(printf '%s\n' "${src_files}") | head -1)"
+
+    if [ -n "${newer_file}" ] || [ -n "${deleted_file}" ]; then
+        if [ -n "${newer_file}" ]; then
+            echo "[WARN] ${DEFAULT_SUBMIT_TAR} is older than ${newer_file}" >&2
+        fi
+        if [ -n "${deleted_file}" ]; then
+            echo "[WARN] ${DEFAULT_SUBMIT_TAR} still contains ${deleted_file}, which no longer exists under ${SUBMIT_SRC_DIR}" >&2
+        fi
         echo "[WARN] The eval image will contain the submission as it was when the tarball was made." >&2
         echo "[WARN] Run ./create_submit_file.bash first to evaluate your current code." >&2
         if [ "${AIC_STRICT_SUBMIT:-0}" = "1" ]; then


### PR DESCRIPTION
`./docker_build.sh eval` は `submit/aichallenge_submit.tar.gz` をそのまま評価イメージに入れます。`./create_submit_file.bash` の後にコードを直すと、`make eval` は古いコードを黙って評価します。
既定の tar（`--submit` 省略時、または `--submit submit/aichallenge_submit.tar.gz`）より新しいファイルが `aichallenge/workspace/src/aichallenge_submit` にある場合、警告を 3 行表示するようにしました。ビルドは従来どおり続行します。`AIC_STRICT_SUBMIT=1` のときだけエラー終了します（opt-in）。別の場所の tar を `--submit` で渡した場合は比較しません。
確認: tar 作成後に config.yaml を編集、修正前は無警告、修正後は WARN 表示、`AIC_STRICT_SUBMIT=1` で exit 1、再作成後は警告なし。ubuntu:22.04 上で fake docker バイナリを使って検証しました。

`./docker_build.sh eval` bakes `submit/aichallenge_submit.tar.gz` into the eval image as is. If code was edited after the last `./create_submit_file.bash`, `make eval` silently scores the old code.

When a file under `aichallenge/workspace/src/aichallenge_submit` is newer than the default tarball (no `--submit`, or `--submit submit/aichallenge_submit.tar.gz`), the script now prints a three-line warning and continues the build as before. `AIC_STRICT_SUBMIT=1` turns the warning into an error (opt-in). A tarball passed from elsewhere is not compared with the local tree.

Tested in an `ubuntu:22.04` container with a fake `docker` binary on PATH, packing the tarball then editing `config.yaml`:
- Unpatched: no output, `exit=0` for both the plain run and `AIC_STRICT_SUBMIT=1`.
- Patched: the plain run prints
  ```
  [WARN] submit/aichallenge_submit.tar.gz is older than aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/config/config.yaml
  [WARN] The eval image will contain the submission as it was when the tarball was made.
  [WARN] Run ./create_submit_file.bash first to evaluate your current code.
  ```
  and continues to build (`exit=0`); `AIC_STRICT_SUBMIT=1` exits 1 after the same three lines; after re-running `./create_submit_file.bash` the warning is gone (`WARN lines after re-packing: 0`, `exit=0`).
- `bash -n`, `shellcheck`, `shfmt -d -s -i 4`, and `pre-commit run --files docker_build.sh` are all clean on the patched file.

Duplicate check: our own card ISSUE-08-docker-build-eval-stale-tarball.md is the issue text for this same bug, with an external participant report (Zenn, tamasy, 2026-06-27). Post ISSUE-08 first, then open this PR with `Closes #<ISSUE-08 number>`. Do not file a second issue.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
