### PR TITLE
fix(mpc): clip obstacle stamp at occupancy-grid edge in Map.add_obstacles

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/map.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/map.py
@@ -159,8 +159,18 @@ class Map:
             # Add circular object to map
             y, x = np.ogrid[-radius_px: radius_px, -radius_px: radius_px]
             index = x ** 2 + y ** 2 <= radius_px ** 2
-            self.data[cy_px-radius_px:cy_px+radius_px, cx_px-radius_px:
-                                                cx_px+radius_px][index] = 0
+            # Clip the stamp to the grid. Near an edge the destination slice is
+            # shorter than the (2r, 2r) mask, or wraps for a negative start, and
+            # the boolean index raised IndexError (controller crash).
+            # グリッド端では書き込み範囲とマスクを同じ範囲に切り出す（内部は従来と同一）。
+            h, w = self.data.shape
+            y0, y1 = cy_px - radius_px, cy_px + radius_px
+            x0, x1 = cx_px - radius_px, cx_px + radius_px
+            yy0, yy1 = max(0, y0), min(h, y1)
+            xx0, xx1 = max(0, x0), min(w, x1)
+            if yy0 < yy1 and xx0 < xx1:
+                sub = index[yy0 - y0:yy1 - y0, xx0 - x0:xx1 - x0]
+                self.data[yy0:yy1, xx0:xx1][sub] = 0
 
     def add_boundary(self, boundaries):
         """

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the ROS-free test helpers (mpc_fixture, ros_stubs) importable.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/mpc_fixture.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/mpc_fixture.py
@@ -1,0 +1,96 @@
+"""Synthetic, ROS-free fixture for MPC regression tests.
+
+Builds a ring-shaped track (inner radius 26 m, outer 34 m) on an in-memory
+occupancy grid and wires it to the real ``ReferencePath``, ``BicycleModel`` and
+``MPC`` classes with the parameters of ``config/config.yaml``.  No files, no
+rclpy -- only numpy / scipy / osqp / scikit-image, which the package already
+requires.
+"""
+import math
+
+import numpy as np
+from scipy import sparse
+
+from multi_purpose_mpc_ros.core.map import Map
+from multi_purpose_mpc_ros.core.reference_path import ReferencePath
+from multi_purpose_mpc_ros.core.spatial_bicycle_models import BicycleModel
+from multi_purpose_mpc_ros.core.MPC import MPC
+
+# Values mirrored from config/config.yaml
+MAP_RES = 0.1
+PATH_RES = 0.6
+SMOOTHING = 2
+MAX_WIDTH = 6.0
+CAR_LENGTH = 1.087
+CAR_WIDTH = 2.30
+N = 20
+Q = [3000000.0, 90000000.0, 100000.0]
+R = [100000.0, 0.0]
+QN = [1000000.0, 1000.0, 10000.0]
+V_MAX = 20.0 / 3.6
+A_MIN, A_MAX = -1.6, 0.7
+AY_MAX = 6.5
+DELTA_MAX = math.radians(32.0)
+STEER_RATE = 0.35 / 1.639
+CONTROL_RATE = 40.0
+WP_ID_OFFSET = 2
+
+
+def ring_map(r_in=26.0, r_out=34.0, size_m=80.0):
+    """Occupancy grid with a free annulus; 1 = free, 0 = occupied."""
+    m = Map.__new__(Map)  # bypass the yaml/pgm loader
+    n = int(size_m / MAP_RES)
+    m.resolution = MAP_RES
+    m.origin = [-size_m / 2.0, -size_m / 2.0, 0.0]
+    m.height = n
+    m.width = n
+    rows, cols = np.meshgrid(np.arange(n), np.arange(n), indexing="ij")
+    x = cols * MAP_RES + m.origin[0]
+    y = (n - 1 - rows) * MAP_RES + m.origin[1]
+    r = np.hypot(x, y)
+    m.data = ((r > r_in) & (r < r_out)).astype(np.int8)
+    m.data_backup = m.data.copy()
+    m.obstacles = []
+    m.boundaries = []
+    m.threshold_occupied = 0.65
+    return m
+
+
+def ring_path(track_map, radius=30.0, n_pts=96):
+    t = np.linspace(0.0, 2.0 * math.pi, n_pts, endpoint=False)
+    wp_x = list(radius * np.cos(t))
+    wp_y = list(radius * np.sin(t))
+    return ReferencePath(track_map, wp_x, wp_y, PATH_RES, SMOOTHING, MAX_WIDTH, True)
+
+
+def make_mpc(**mpc_kwargs):
+    track_map = ring_map()
+    ref = ring_path(track_map)
+    car = BicycleModel(ref, CAR_LENGTH, CAR_WIDTH, 1.0 / CONTROL_RATE)
+    state_constraints = {
+        "xmin": np.array([-np.inf, -np.inf, -np.inf]),
+        "xmax": np.array([np.inf, np.inf, np.inf])}
+    input_constraints = {
+        "umin": np.array([0.0, -np.tan(DELTA_MAX) / CAR_LENGTH]),
+        "umax": np.array([V_MAX, np.tan(DELTA_MAX) / CAR_LENGTH])}
+    mpc = MPC(car, N, sparse.diags(Q), sparse.diags(R), sparse.diags(QN),
+              state_constraints, input_constraints, AY_MAX, STEER_RATE,
+              WP_ID_OFFSET, False, False, True, **mpc_kwargs)
+    ref.compute_speed_profile({"a_min": A_MIN, "a_max": A_MAX, "v_min": 0.0,
+                               "v_max": V_MAX, "ay_max": AY_MAX})
+    return mpc
+
+
+def place_car(mpc, wp_index, e_y, e_psi):
+    """Put the car at lateral offset e_y [m] (left +) and heading error e_psi
+    [rad] relative to waypoint ``wp_index``."""
+    wp = mpc.model.reference_path.waypoints[wp_index]
+    x = wp.x - e_y * math.sin(wp.psi)
+    y = wp.y + e_y * math.cos(wp.psi)
+    mpc.model.update_states(x, y, wp.psi + e_psi)
+
+
+def corridor_rows(mpc):
+    """Copy of the stored per-waypoint corridor tables (ub, lb)."""
+    ub, lb = mpc.model.reference_path.path_constraints
+    return ub.copy(), lb.copy()

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_map_add_obstacles.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_map_add_obstacles.py
@@ -1,0 +1,50 @@
+"""Map.add_obstacles must not raise when an obstacle overlaps the grid edge.
+
+The circular mask is always (2r, 2r) but the destination slice is clipped by
+numpy at the far edge and wraps / empties at the near edge (negative start),
+so the boolean index no longer matches and IndexError kills the controller
+the first time an obstacle (e.g. a V2X opponent) comes within r px of an edge.
+"""
+import numpy as np
+import pytest
+
+from multi_purpose_mpc_ros.core.map import Obstacle
+
+from mpc_fixture import ring_map
+
+
+def _reference_paint(data, cx_px, cy_px, radius_px):
+    """The pre-fix algorithm, for obstacles fully inside the grid."""
+    y, x = np.ogrid[-radius_px: radius_px, -radius_px: radius_px]
+    index = x ** 2 + y ** 2 <= radius_px ** 2
+    data[cy_px - radius_px:cy_px + radius_px,
+         cx_px - radius_px:cx_px + radius_px][index] = 0
+
+
+@pytest.mark.parametrize("cx, cy", [
+    (39.95, 0.0),     # right edge  -> slice clipped at the far end
+    (0.0, -39.95),    # bottom edge -> slice clipped at the far end
+    (-39.95, 0.0),    # left edge   -> negative start wraps to an empty slice
+    (0.0, 39.95),     # top edge    -> negative start wraps to an empty slice
+    (-39.95, 39.95),  # corner
+])
+def test_obstacle_on_grid_edge_does_not_raise(cx, cy):
+    m = ring_map()
+    m.data[:] = 1
+    m.add_obstacles([Obstacle(cx=cx, cy=cy, radius=1.25)])
+    cx_px, cy_px = m.w2m(cx, cy)
+    assert m.data[cy_px, cx_px] == 0          # the part inside the grid is painted
+    assert (m.data == 0).sum() > 0
+
+
+def test_interior_obstacle_is_painted_exactly_as_before():
+    m = ring_map()
+    expected = m.data.copy()
+    obstacle = Obstacle(cx=30.0, cy=0.5, radius=1.25)
+    radius_px = int(np.ceil(obstacle.radius / m.resolution))
+    cx_px, cy_px = m.w2m(obstacle.cx, obstacle.cy)
+    _reference_paint(expected, cx_px, cy_px, radius_px)
+
+    m.add_obstacles([obstacle])
+
+    assert np.array_equal(m.data, expected)


### PR DESCRIPTION
## 概要
`core/map.py` の `add_obstacles()` で、障害物が occupancy grid の端にかかると IndexError になり、MPC ノードが停止する問題を修正します。

## 原因
円形マスク `index` は常に (2r, 2r) の大きさです。一方、書き込み先スライスは次のようになります。
- 奥側の端: numpy に切り詰められる
- 手前側の端: 負のインデックスで wrap して空になる

そのため、ブールインデックスの形が合いません。`w2m()` は座標をグリッド内に clip するので、グリッド外の障害物は必ず端に置かれ、必ず落ちます。`use_obstacle_avoidance:=true`（V2X 障害物回避）では、`_control()` → `add_obstacles()` からこの例外が捕捉されずに抜け、制御ループが終了します。

## 修正
書き込み範囲をグリッド内に clip し、マスクも同じ範囲だけ切り出します。グリッド内部の障害物の描画は従来と完全に同一です（テストで旧実装と比較）。

## テスト
`test/test_map_add_obstacles.py`（ROS 不要）
- 修正前: 端・角の 5 ケースが IndexError（`5 failed, 1 passed`）
- 修正後: 全件パス（`20 passed`）

---

## Summary
Fixes an IndexError in `core/map.py` `add_obstacles()` that kills the MPC node when an obstacle overlaps the occupancy-grid edge.

## Cause
The circular mask is always (2r, 2r). The destination slice is shortened at the far edge and wraps to an empty slice at the near edge (negative start), so the boolean index no longer matches. `w2m()` clips coordinates into the grid, so any off-grid obstacle is placed on the edge and always raises. With `use_obstacle_avoidance:=true` the exception escapes `_control()`, and the control loop ends.

## Fix
Clip the destination window to the grid and cut the mask to the same window. Interior obstacles are painted exactly as before; the test compares against the old algorithm.

## Test
`test/test_map_add_obstacles.py` (no ROS)
- before: 5 edge/corner cases raise IndexError (`5 failed, 1 passed`)
- after: all pass (`20 passed`)

Verified locally with:
```
uv run --python 3.10 --with numpy==2.0.1 --with osqp==0.6.7.post1 --with scipy --with scikit-image==0.24.0 --with matplotlib==3.9.0 --with pillow --with PyYAML==6.0.1 --with pandas==2.2.2 --with pytest python -m pytest test/test_map_add_obstacles.py test/ -q
```

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
