### PR TITLE
fix(mpc): do not modify stored path constraints during safety-margin relaxation

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/MPC.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/MPC.py
@@ -150,8 +150,11 @@ class MPC:
                 N, self.model.length, self.model.width, safety_margin)
         else:
             ref_wp_id = (self.model.wp_id + 1) % len(self.model.reference_path.path_constraints[0])
-            ub = self.model.reference_path.path_constraints[0][ref_wp_id]
-            lb = self.model.reference_path.path_constraints[1][ref_wp_id]
+            # Copy: the relaxation below edits ub/lb in place, and a numpy row is a
+            # view into the stored table, so every relaxed retry permanently widened
+            # the corridor for this waypoint. 行はビューなのでコピーしてから編集する。
+            ub = self.model.reference_path.path_constraints[0][ref_wp_id].copy()
+            lb = self.model.reference_path.path_constraints[1][ref_wp_id].copy()
             self.model.reference_path.border_cells.current_wp_id = ref_wp_id
 
             # Update safety margin if provided as argument and different from current value

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the ROS-free test helpers (mpc_fixture, ros_stubs) importable.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/mpc_fixture.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/mpc_fixture.py
@@ -1,0 +1,96 @@
+"""Synthetic, ROS-free fixture for MPC regression tests.
+
+Builds a ring-shaped track (inner radius 26 m, outer 34 m) on an in-memory
+occupancy grid and wires it to the real ``ReferencePath``, ``BicycleModel`` and
+``MPC`` classes with the parameters of ``config/config.yaml``.  No files, no
+rclpy -- only numpy / scipy / osqp / scikit-image, which the package already
+requires.
+"""
+import math
+
+import numpy as np
+from scipy import sparse
+
+from multi_purpose_mpc_ros.core.map import Map
+from multi_purpose_mpc_ros.core.reference_path import ReferencePath
+from multi_purpose_mpc_ros.core.spatial_bicycle_models import BicycleModel
+from multi_purpose_mpc_ros.core.MPC import MPC
+
+# Values mirrored from config/config.yaml
+MAP_RES = 0.1
+PATH_RES = 0.6
+SMOOTHING = 2
+MAX_WIDTH = 6.0
+CAR_LENGTH = 1.087
+CAR_WIDTH = 2.30
+N = 20
+Q = [3000000.0, 90000000.0, 100000.0]
+R = [100000.0, 0.0]
+QN = [1000000.0, 1000.0, 10000.0]
+V_MAX = 20.0 / 3.6
+A_MIN, A_MAX = -1.6, 0.7
+AY_MAX = 6.5
+DELTA_MAX = math.radians(32.0)
+STEER_RATE = 0.35 / 1.639
+CONTROL_RATE = 40.0
+WP_ID_OFFSET = 2
+
+
+def ring_map(r_in=26.0, r_out=34.0, size_m=80.0):
+    """Occupancy grid with a free annulus; 1 = free, 0 = occupied."""
+    m = Map.__new__(Map)  # bypass the yaml/pgm loader
+    n = int(size_m / MAP_RES)
+    m.resolution = MAP_RES
+    m.origin = [-size_m / 2.0, -size_m / 2.0, 0.0]
+    m.height = n
+    m.width = n
+    rows, cols = np.meshgrid(np.arange(n), np.arange(n), indexing="ij")
+    x = cols * MAP_RES + m.origin[0]
+    y = (n - 1 - rows) * MAP_RES + m.origin[1]
+    r = np.hypot(x, y)
+    m.data = ((r > r_in) & (r < r_out)).astype(np.int8)
+    m.data_backup = m.data.copy()
+    m.obstacles = []
+    m.boundaries = []
+    m.threshold_occupied = 0.65
+    return m
+
+
+def ring_path(track_map, radius=30.0, n_pts=96):
+    t = np.linspace(0.0, 2.0 * math.pi, n_pts, endpoint=False)
+    wp_x = list(radius * np.cos(t))
+    wp_y = list(radius * np.sin(t))
+    return ReferencePath(track_map, wp_x, wp_y, PATH_RES, SMOOTHING, MAX_WIDTH, True)
+
+
+def make_mpc(**mpc_kwargs):
+    track_map = ring_map()
+    ref = ring_path(track_map)
+    car = BicycleModel(ref, CAR_LENGTH, CAR_WIDTH, 1.0 / CONTROL_RATE)
+    state_constraints = {
+        "xmin": np.array([-np.inf, -np.inf, -np.inf]),
+        "xmax": np.array([np.inf, np.inf, np.inf])}
+    input_constraints = {
+        "umin": np.array([0.0, -np.tan(DELTA_MAX) / CAR_LENGTH]),
+        "umax": np.array([V_MAX, np.tan(DELTA_MAX) / CAR_LENGTH])}
+    mpc = MPC(car, N, sparse.diags(Q), sparse.diags(R), sparse.diags(QN),
+              state_constraints, input_constraints, AY_MAX, STEER_RATE,
+              WP_ID_OFFSET, False, False, True, **mpc_kwargs)
+    ref.compute_speed_profile({"a_min": A_MIN, "a_max": A_MAX, "v_min": 0.0,
+                               "v_max": V_MAX, "ay_max": AY_MAX})
+    return mpc
+
+
+def place_car(mpc, wp_index, e_y, e_psi):
+    """Put the car at lateral offset e_y [m] (left +) and heading error e_psi
+    [rad] relative to waypoint ``wp_index``."""
+    wp = mpc.model.reference_path.waypoints[wp_index]
+    x = wp.x - e_y * math.sin(wp.psi)
+    y = wp.y + e_y * math.cos(wp.psi)
+    mpc.model.update_states(x, y, wp.psi + e_psi)
+
+
+def corridor_rows(mpc):
+    """Copy of the stored per-waypoint corridor tables (ub, lb)."""
+    ub, lb = mpc.model.reference_path.path_constraints
+    return ub.copy(), lb.copy()

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_relaxation_corridor.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_relaxation_corridor.py
@@ -1,0 +1,71 @@
+"""The safety-margin relaxation retry in MPC.get_control must not modify the stored corridor table.
+
+State used throughout: the car is 2.3 m left of the reference line with a
+0.45 rad heading error.  Row 0 of the spatial model has no input authority
+(b_1 == [0, 0]), so e_y_1 = e_y_0 + ds * e_psi_0 = 2.57 m, which is outside the
+2.36 m corridor: the first QP is primal infeasible by construction and
+get_control enters the relaxation loop.
+"""
+import numpy as np
+
+import mpc_fixture as F
+
+WP = 10
+E_Y, E_PSI = 2.3, 0.45
+
+
+def test_state_really_is_infeasible_for_the_hard_qp():
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, E_Y, E_PSI)
+    mpc.model.get_current_waypoint()
+    mpc.model.spatial_state = mpc.model.t2s(
+        reference_state=mpc.model.temporal_state,
+        reference_waypoint=mpc.model.current_waypoint)
+    mpc._init_problem(F.N, mpc.model.safety_margin)
+    assert mpc.optimizer.solve().info.status == "primal infeasible"
+
+
+def test_relaxation_does_not_rewrite_the_stored_corridor(capsys):
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, E_Y, E_PSI)
+    ub_before, lb_before = F.corridor_rows(mpc)
+
+    mpc.get_control()
+
+    assert "Relaxed safety margin" in capsys.readouterr().out  # the loop ran
+    ub_after, lb_after = F.corridor_rows(mpc)
+    assert np.array_equal(ub_after, ub_before), \
+        f"corridor widened by {np.max(ub_after - ub_before):.3f} m"
+    assert np.array_equal(lb_after, lb_before)
+
+
+def test_next_tick_sees_the_original_corridor():
+    """After one infeasible tick, a car back on the line must get the same
+    plan as a car that never had one."""
+    fresh = F.make_mpc()
+    F.place_car(fresh, WP, 0.0, 0.0)
+    u_fresh, _ = fresh.get_control()
+
+    used = F.make_mpc()
+    F.place_car(used, WP, E_Y, E_PSI)
+    used.get_control()
+    used.previous_steering = 0.0
+    used.current_control = np.zeros_like(used.current_control)
+    F.place_car(used, WP, 0.0, 0.0)
+    u_used, _ = used.get_control()
+
+    assert np.allclose(u_used, u_fresh, atol=1e-9)
+
+
+def test_feasible_tick_is_unchanged():
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, 0.0, 0.0)
+    mpc.model.get_current_waypoint()
+    base = mpc.model.wp_id
+    ub_before, _ = F.corridor_rows(mpc)
+
+    u, _ = mpc.get_control()
+
+    assert mpc.model.wp_id == base + F.WP_ID_OFFSET
+    assert np.array_equal(F.corridor_rows(mpc)[0], ub_before)
+    assert np.all(np.isfinite(u))


### PR DESCRIPTION
## 概要
`MPC._init_problem()` の safety margin 緩和で、保存済みのコリドー表（`reference_path.path_constraints`）を直接書き換えてしまい、コリドーが恒久的に広がる問題を修正します。

## 原因
`path_constraints[0][ref_wp_id]` は numpy のビューです。緩和時の `ub -= safety_margin_diff` / `lb += ...` がそのまま保存済みの表に反映されます。表は `MPC.__init__` で 1 回作られるだけで、再計算されません。

固定されている osqp 0.6.7 では、infeasible 時に `x=[None,...]` が返ります。そのため `np.all(...)` が False になり、既定構成（`use_obstacle_avoidance=false`）でも緩和ループに入ります。1 回の緩和で 0.325 m、5 回すべてで最大 4.9 m（片側）広がります。

## 修正
行を `.copy()` してから編集します（2 行）。

## テスト
`test/test_mpc_relaxation_corridor.py`（ROS 不要）
- 修正前: `corridor widened by 0.325 m`（`1 failed, 3 passed`）
- 修正後: パス（`18 passed`）。次周期の解が、infeasible を経験していない場合と一致することも確認します

---

## Summary
Stops the safety-margin relaxation in `MPC._init_problem()` from editing the stored corridor table (`reference_path.path_constraints`) in place. That edit widened the corridor permanently.

## Cause
`path_constraints[0][ref_wp_id]` is a numpy view, so `ub -= safety_margin_diff` / `lb += ...` write straight into the stored table. The table is built once, in `MPC.__init__`, and never rebuilt.

With the pinned osqp 0.6.7 an infeasible solve returns `x=[None,...]`, so `np.all(...)` is False and the relaxation loop runs, even in the default configuration (`use_obstacle_avoidance=false`). One relaxed retry widens a row by 0.325 m; all five widen it by up to 4.9 m per side.

## Fix
`.copy()` each row before editing it (2 lines).

## Test
`test/test_mpc_relaxation_corridor.py` (no ROS)
- before: `corridor widened by 0.325 m` (`1 failed, 3 passed`)
- after: passes (`18 passed`); the test also checks that the next tick's plan equals that of a controller that never went infeasible

Verified locally with:
```
uv run --python 3.10 --with numpy==2.0.1 --with osqp==0.6.7.post1 --with scipy --with scikit-image==0.24.0 --with matplotlib==3.9.0 --with pillow --with PyYAML==6.0.1 --with pandas==2.2.2 --with pytest python -m pytest test/test_mpc_relaxation_corridor.py test/ -q
```

Pairs with RK-CTRL-05 and RK-CTRL-06 (three independent bugs on the same relaxation retry path).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
