### PR TITLE
fix(mpc): keep the horizon anchored during safety-margin relaxation retries

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/MPC.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/multi_purpose_mpc_ros/core/MPC.py
@@ -237,6 +237,9 @@ class MPC:
         nu = self.nu
 
         self.model.get_current_waypoint()
+        # _init_problem() advances wp_id by wp_id_offset (control delay); remember
+        # the car's own waypoint so every relaxation retry starts from it.
+        wp_id_base = self.model.wp_id
 
         N = min(self.N, self.model.reference_path.n_waypoints - self.model.wp_id) \
             if not self.model.reference_path.circular else self.N
@@ -255,6 +258,7 @@ class MPC:
             if not np.all(use_control_signals):
                 for i in range(1, 6):
                     relaxed_safety_margin = self.model.safety_margin * ((5-i) / 5.0)
+                    self.model.wp_id = wp_id_base
                     self._init_problem(N, relaxed_safety_margin)
                     dec = self.optimizer.solve()
                     control_signals = np.array(dec.x[-N*nu:])

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the ROS-free test helpers (mpc_fixture, ros_stubs) importable.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/mpc_fixture.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/mpc_fixture.py
@@ -1,0 +1,96 @@
+"""Synthetic, ROS-free fixture for MPC regression tests.
+
+Builds a ring-shaped track (inner radius 26 m, outer 34 m) on an in-memory
+occupancy grid and wires it to the real ``ReferencePath``, ``BicycleModel`` and
+``MPC`` classes with the parameters of ``config/config.yaml``.  No files, no
+rclpy -- only numpy / scipy / osqp / scikit-image, which the package already
+requires.
+"""
+import math
+
+import numpy as np
+from scipy import sparse
+
+from multi_purpose_mpc_ros.core.map import Map
+from multi_purpose_mpc_ros.core.reference_path import ReferencePath
+from multi_purpose_mpc_ros.core.spatial_bicycle_models import BicycleModel
+from multi_purpose_mpc_ros.core.MPC import MPC
+
+# Values mirrored from config/config.yaml
+MAP_RES = 0.1
+PATH_RES = 0.6
+SMOOTHING = 2
+MAX_WIDTH = 6.0
+CAR_LENGTH = 1.087
+CAR_WIDTH = 2.30
+N = 20
+Q = [3000000.0, 90000000.0, 100000.0]
+R = [100000.0, 0.0]
+QN = [1000000.0, 1000.0, 10000.0]
+V_MAX = 20.0 / 3.6
+A_MIN, A_MAX = -1.6, 0.7
+AY_MAX = 6.5
+DELTA_MAX = math.radians(32.0)
+STEER_RATE = 0.35 / 1.639
+CONTROL_RATE = 40.0
+WP_ID_OFFSET = 2
+
+
+def ring_map(r_in=26.0, r_out=34.0, size_m=80.0):
+    """Occupancy grid with a free annulus; 1 = free, 0 = occupied."""
+    m = Map.__new__(Map)  # bypass the yaml/pgm loader
+    n = int(size_m / MAP_RES)
+    m.resolution = MAP_RES
+    m.origin = [-size_m / 2.0, -size_m / 2.0, 0.0]
+    m.height = n
+    m.width = n
+    rows, cols = np.meshgrid(np.arange(n), np.arange(n), indexing="ij")
+    x = cols * MAP_RES + m.origin[0]
+    y = (n - 1 - rows) * MAP_RES + m.origin[1]
+    r = np.hypot(x, y)
+    m.data = ((r > r_in) & (r < r_out)).astype(np.int8)
+    m.data_backup = m.data.copy()
+    m.obstacles = []
+    m.boundaries = []
+    m.threshold_occupied = 0.65
+    return m
+
+
+def ring_path(track_map, radius=30.0, n_pts=96):
+    t = np.linspace(0.0, 2.0 * math.pi, n_pts, endpoint=False)
+    wp_x = list(radius * np.cos(t))
+    wp_y = list(radius * np.sin(t))
+    return ReferencePath(track_map, wp_x, wp_y, PATH_RES, SMOOTHING, MAX_WIDTH, True)
+
+
+def make_mpc(**mpc_kwargs):
+    track_map = ring_map()
+    ref = ring_path(track_map)
+    car = BicycleModel(ref, CAR_LENGTH, CAR_WIDTH, 1.0 / CONTROL_RATE)
+    state_constraints = {
+        "xmin": np.array([-np.inf, -np.inf, -np.inf]),
+        "xmax": np.array([np.inf, np.inf, np.inf])}
+    input_constraints = {
+        "umin": np.array([0.0, -np.tan(DELTA_MAX) / CAR_LENGTH]),
+        "umax": np.array([V_MAX, np.tan(DELTA_MAX) / CAR_LENGTH])}
+    mpc = MPC(car, N, sparse.diags(Q), sparse.diags(R), sparse.diags(QN),
+              state_constraints, input_constraints, AY_MAX, STEER_RATE,
+              WP_ID_OFFSET, False, False, True, **mpc_kwargs)
+    ref.compute_speed_profile({"a_min": A_MIN, "a_max": A_MAX, "v_min": 0.0,
+                               "v_max": V_MAX, "ay_max": AY_MAX})
+    return mpc
+
+
+def place_car(mpc, wp_index, e_y, e_psi):
+    """Put the car at lateral offset e_y [m] (left +) and heading error e_psi
+    [rad] relative to waypoint ``wp_index``."""
+    wp = mpc.model.reference_path.waypoints[wp_index]
+    x = wp.x - e_y * math.sin(wp.psi)
+    y = wp.y + e_y * math.cos(wp.psi)
+    mpc.model.update_states(x, y, wp.psi + e_psi)
+
+
+def corridor_rows(mpc):
+    """Copy of the stored per-waypoint corridor tables (ub, lb)."""
+    ub, lb = mpc.model.reference_path.path_constraints
+    return ub.copy(), lb.copy()

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_relaxation_horizon.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_relaxation_horizon.py
@@ -9,6 +9,7 @@ get_control enters the relaxation loop.
 import numpy as np
 
 import mpc_fixture as F
+from multi_purpose_mpc_ros.core import MPC as mpc_module
 
 WP = 10
 E_Y, E_PSI = 2.3, 0.45
@@ -34,6 +35,50 @@ def test_relaxation_keeps_the_horizon_anchored_to_the_car():
     mpc.get_control()
 
     # One control-delay offset, however many relaxation retries ran.
+    assert mpc.model.wp_id == base + F.WP_ID_OFFSET
+
+
+def test_relaxation_retry_is_exercised_and_horizon_stays_anchored(monkeypatch):
+    """The previous version of this test relied on OSQP 0.6.7 happening to
+    return an all-None ``x`` for a primal-infeasible QP (which ``np.all``
+    treats as falsy), so the retry loop ran only incidentally. That is not
+    a stable contract across osqp versions/results, so force the retry path
+    explicitly: rig the first solve's control signals to be all-zero
+    steering (the loop's own "unusable" predicate) regardless of what OSQP
+    itself returns, then assert a retry actually happened and wp_id stayed
+    anchored to the car afterward.
+    """
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, 0.0, 0.0)  # an otherwise-feasible starting state
+    mpc.model.get_current_waypoint()
+    base = mpc.model.wp_id
+
+    calls = {"n": 0}
+    orig_solve = mpc_module.osqp.OSQP.solve
+    nu = mpc.nu
+    tail = -(F.N * nu)
+
+    class _RiggedResult:
+        """``result.x`` is read-only on the real OSQP result, so wrap it in a
+        proxy that exposes a rigged ``x`` alongside the real ``info``."""
+        def __init__(self, x, info):
+            self.x = x
+            self.info = info
+
+    def spy_solve(self):
+        calls["n"] += 1
+        result = orig_solve(self)
+        if calls["n"] == 1:
+            x = np.array(result.x, dtype=float)
+            x[tail + 1::2] = 0.0  # force the "unusable" (falsy) predicate
+            return _RiggedResult(x, result.info)
+        return result
+
+    monkeypatch.setattr(mpc_module.osqp.OSQP, "solve", spy_solve)
+
+    mpc.get_control()
+
+    assert calls["n"] >= 2, "get_control did not retry after the forced-unusable first solve"
     assert mpc.model.wp_id == base + F.WP_ID_OFFSET
 
 

--- a/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_relaxation_horizon.py
+++ b/aichallenge/workspace/src/aichallenge_submit/multi_purpose_mpc_ros/test/test_mpc_relaxation_horizon.py
@@ -1,0 +1,51 @@
+"""The safety-margin relaxation retry in MPC.get_control must keep the horizon anchored to the car.
+
+State used throughout: the car is 2.3 m left of the reference line with a
+0.45 rad heading error.  Row 0 of the spatial model has no input authority
+(b_1 == [0, 0]), so e_y_1 = e_y_0 + ds * e_psi_0 = 2.57 m, which is outside the
+2.36 m corridor: the first QP is primal infeasible by construction and
+get_control enters the relaxation loop.
+"""
+import numpy as np
+
+import mpc_fixture as F
+
+WP = 10
+E_Y, E_PSI = 2.3, 0.45
+
+
+def test_state_really_is_infeasible_for_the_hard_qp():
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, E_Y, E_PSI)
+    mpc.model.get_current_waypoint()
+    mpc.model.spatial_state = mpc.model.t2s(
+        reference_state=mpc.model.temporal_state,
+        reference_waypoint=mpc.model.current_waypoint)
+    mpc._init_problem(F.N, mpc.model.safety_margin)
+    assert mpc.optimizer.solve().info.status == "primal infeasible"
+
+
+def test_relaxation_keeps_the_horizon_anchored_to_the_car():
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, E_Y, E_PSI)
+    mpc.model.get_current_waypoint()
+    base = mpc.model.wp_id
+
+    mpc.get_control()
+
+    # One control-delay offset, however many relaxation retries ran.
+    assert mpc.model.wp_id == base + F.WP_ID_OFFSET
+
+
+def test_feasible_tick_is_unchanged():
+    mpc = F.make_mpc()
+    F.place_car(mpc, WP, 0.0, 0.0)
+    mpc.model.get_current_waypoint()
+    base = mpc.model.wp_id
+    ub_before, _ = F.corridor_rows(mpc)
+
+    u, _ = mpc.get_control()
+
+    assert mpc.model.wp_id == base + F.WP_ID_OFFSET
+    assert np.array_equal(F.corridor_rows(mpc)[0], ub_before)
+    assert np.all(np.isfinite(u))


### PR DESCRIPTION
## 概要
`get_control()` の safety margin 緩和のリトライごとに、`_init_problem()` 内の `self.model.wp_id += self.wp_id_offset` が累積し、予測区間が前方にずれていく問題を修正します。

## 詳細
既定の `wp_id_offset: 2`・waypoint 間隔 0.6 m では、i 回目のリトライのコリドー・参照が、車両の状態より 1.2·i m 先から始まります。5 回すべてで 6 m 先になります。`x0`（e_y, e_psi）は車両の waypoint 基準のままなので、苦しい周期ほど計画がずれます。

## 修正
最初の `_init_problem` の前に車両の waypoint を記録し、各リトライの前に戻します（+4 行）。

## テスト
`test/test_mpc_relaxation_horizon.py`
- 修正前: `wp_id` が 12 ではなく 14 になる（`1 failed, 2 passed`）
- 修正後: パス（`17 passed`）

---

## Summary
Each safety-margin relaxation retry in `get_control()` calls `_init_problem()` again, and its `self.model.wp_id += self.wp_id_offset` accumulates, so the horizon creeps forward.

## Details
With the default `wp_id_offset: 2` and 0.6 m waypoints, retry i plans from 1.2·i m ahead of the car's state; after five retries that is 6 m. `x0` (e_y, e_psi) is still relative to the car's waypoint, so the plan is misaligned exactly on the hard ticks.

## Fix
Record the car's waypoint before the first `_init_problem` and restore it before each retry (+4 lines).

## Test
`test/test_mpc_relaxation_horizon.py`
- before: `wp_id` ends at 14 instead of 12 (`1 failed, 2 passed`)
- after: passes (`17 passed`)

Verified locally with:
```
uv run --python 3.10 --with numpy==2.0.1 --with osqp==0.6.7.post1 --with scipy --with scikit-image==0.24.0 --with matplotlib==3.9.0 --with pillow --with PyYAML==6.0.1 --with pandas==2.2.2 --with pytest python -m pytest test/test_mpc_relaxation_horizon.py test/ -q
```

Independent of RK-CTRL-04 (both touch the relaxation retry path but different defects); pairs with RK-CTRL-06.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
