### PR TITLE
fix(simple_pure_pursuit): use tf2::getYaw for the rear-axle reference point

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -82,10 +82,9 @@ void SimplePurePursuit::onTimer()
   //// calc lookahead distance
   double lookahead_distance = lookahead_gain_ * target_longitudinal_vel + lookahead_min_distance_;
   //// calc center coordinate of rear wheel
-  double rear_x = odometry_->pose.pose.position.x -
-                  wheel_base_ / 2.0 * std::cos(odometry_->pose.pose.orientation.z);
-  double rear_y = odometry_->pose.pose.position.y -
-                  wheel_base_ / 2.0 * std::sin(odometry_->pose.pose.orientation.z);
+  const double yaw = tf2::getYaw(odometry_->pose.pose.orientation);
+  double rear_x = odometry_->pose.pose.position.x - wheel_base_ / 2.0 * std::cos(yaw);
+  double rear_y = odometry_->pose.pose.position.y - wheel_base_ / 2.0 * std::sin(yaw);
   //// search lookahead point
   auto lookahead_point_itr = std::find_if(
     trajectory_->points.begin() + closet_traj_point_idx, trajectory_->points.end(),


### PR DESCRIPTION
## 概要
`simple_pure_pursuit` の後輪軸位置の計算で、クォータニオンの `orientation.z`（= sin(yaw/2)）をヨー角として使っていた問題を修正します。同じ関数の 109 行目では `tf2::getYaw` が正しく使われています。

## 影響
同梱レースライン上に車両を置いて比較しました。
- 後輪軸の位置誤差: 最大 0.95 m
- 操舵指令の誤差: citycircuit で最大 15.8°（平均 0.9°）、kashiwanoha で最大 9.8°（平均 1.1°）

## 修正
`tf2::getYaw` でヨー角を求め、それを使います。

#213 にも同じ変更が含まれています。

## テスト
同梱レースライン上に車両を置き、バグのあるヨーと正しいヨーで操舵指令を比較するハーネス（ROS 不要）を実行しました。
- 修正前: `rear-point displacement max 0.951 m; steering-command error ... max 15.81 deg, mean 0.88 deg over 131 on-line poses`（exit 1）
- 修正後: `worst rear-point displacement = 0.000 m`、`[after] PASS`（exit 0）

---

## Summary
The rear-axle point in `simple_pure_pursuit` used the quaternion component `orientation.z` (= sin(yaw/2)) as the yaw angle. Line 109 of the same function already uses `tf2::getYaw` correctly.

## Effect
Placing the car on the shipped racelines and comparing:
- rear-axle point misplaced by up to 0.95 m
- steering command off by up to 15.81 degrees (mean 0.88, 131 poses) on citycircuit's default raceline and 9.75 degrees (mean 1.07, 377 poses) on kashiwanoha

## Fix
Compute the yaw with `tf2::getYaw` and use it.

The same change is part of #213.

## Test
A ROS-free harness places the car on the shipped raceline and compares the steering command computed with the buggy yaw against the correct yaw.
- before: `rear-point displacement max 0.951 m; steering-command error ... max 15.81 deg, mean 0.88 deg over 131 on-line poses` (exit 1)
- after: `worst rear-point displacement = 0.000 m`, `[after] PASS` (exit 0)

Verified locally with:
```
clang++ -std=c++17 -O1 -o yaw_test yaw_test.cpp && ./yaw_test raceline_awsim_30km_from_garage.csv   # before: exit 1, bug quantified
clang++ -std=c++17 -g -O0 -fsanitize=address -o pp_test pp_test.cpp && ./pp_test raceline_awsim_30km_from_garage.csv after   # after: PASS
```

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
