### PR TITLE
perf(motion_analytics): make topic synchronisation O(N log M)

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/motion_analytics.py
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/motion_analytics.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import bisect
 from datetime import datetime
 import os
 import sys
@@ -67,14 +68,12 @@ def create_reader(input_uri: str) -> SequentialReader:
 
 
 def sync_topic(data1, data2) -> list:
+    # latest data2 sample with t <= data1 t (data2[0] if none); data2 is time-ordered.
+    times2 = [d[0] for d in data2]
     sync_data = []
-    for idx1 in range(len(data1)):
-        data = data2[0]
-        for idx2 in range(len(data2)):
-            if data1[idx1][0] < data2[idx2][0]:
-                break
-            data = data2[idx2]
-        sync_data.append(data)
+    for d1 in data1:
+        idx = bisect.bisect_right(times2, d1[0]) - 1
+        sync_data.append(data2[max(idx, 0)])
     return sync_data
 
 


### PR DESCRIPTION
## 概要
`motion_analytics.py` の `sync_topic()` が、data1 の各要素ごとに data2 を先頭から走査する O(N·M) の実装でした。400 秒・50 Hz 相当（N=20000）で 1 回 7〜11 秒、1 回の実行で 2 回呼ばれます。実行終了処理（`latest/` リンク更新の前）で同期的に走ります。

## 修正
`bisect` による二分探索にします。結果は同一です（t <= t1 の最新サンプル、無ければ data2[0]）。

## テスト
- N=20000: 修正前 11.5 s（環境依存。カード記載の計測値は 7.1 s）→ 修正後 0.02 s
- 小さなケースで旧実装と一致することも確認

---

## Summary
`sync_topic()` in `motion_analytics.py` rescanned data2 from the start for every data1 sample, which is O(N*M). At N=20000 (400 s at 50 Hz) it takes several seconds per call, twice per run, synchronously in the end-of-run path before `latest/` is refreshed.

## Fix
Binary search with `bisect`. Results are identical: the latest sample with t <= t1, else data2[0].

## Test
- N=20000: before 11.5 s (machine-dependent; card measurement was 7.1 s) -> after 0.02 s
- a small case matches the old implementation

Verified locally with:
```
RK_SRC=orig uv run --with pytest --with numpy pytest -q test_motion_analytics_sync.py    # 1 failed, 1 passed (11.5 s)
RK_SRC=fixed uv run --with pytest --with numpy pytest -q test_motion_analytics_sync.py   # 2 passed (0.02 s)
```

Bundle with RK-CTRL-14.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
