### PR TITLE
fix(bag_manager): always stop the recorder on shutdown

### DIFF
--- a/aichallenge/workspace/src/aichallenge_tools/bag_manager_py/bag_manager_py/bag_manager_node.py
+++ b/aichallenge/workspace/src/aichallenge_tools/bag_manager_py/bag_manager_py/bag_manager_node.py
@@ -103,8 +103,8 @@ def main(args=None):
     except KeyboardInterrupt:
         pass
     finally:
+        node.destroy_node()
         if rclpy.ok():
-            node.destroy_node()
             rclpy.shutdown()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概要
`bag_manager_node` を Ctrl-C で止めると、`finally` 節の時点で `rclpy.ok()` が既に False です（SIGINT でコンテキストが終了済み）。そのため `destroy_node()`（= recorder 停止）がスキップされていました。recorder は `os.setsid` で別セッションにあるので、SIGINT も届かず、録画が続いたまま bag が正しく閉じられません。

## 修正
`destroy_node()` は常に呼び、`rclpy.shutdown()` だけを `rclpy.ok()` で保護します。

## テスト
rclpy をスタブしたハーネスで、SIGINT 後にコンテキストが既に終了している状況を再現しました。
- 修正前: recorder が停止されない（`1 failed in 0.01s`）
- 修正後: パス（`1 passed in 0.01s`）

補足: 「コンテキストが SIGINT 後に既に終了している」という前提は既知の Humble の挙動で、テストではスタブしています。実機の ROS 環境では未確認です。

---

## Summary
On Ctrl-C, `rclpy.ok()` is already False in `bag_manager_node`'s `finally` (SIGINT shut the context down), so `destroy_node()`, which stops the recorder, was skipped. The recorder runs in its own session (`os.setsid`), so SIGINT never reaches it: it keeps recording and the bag is not closed cleanly.

## Fix
Always call `destroy_node()`; guard only `rclpy.shutdown()`.

## Test
A harness stubs rclpy to reproduce a context that is already shut down after SIGINT.
- before: recorder is not stopped (`1 failed in 0.01s`)
- after: passes (`1 passed in 0.01s`)

Caveat: the "context already shut down after SIGINT" premise is known Humble behaviour, stubbed in the test; it was not reproduced on a live ROS install.

Verified locally with:
```
RK_SRC=orig uv run --with pytest --with numpy pytest -q test_bag_manager_ctrl_c.py    # 1 failed
RK_SRC=fixed uv run --with pytest --with numpy pytest -q test_bag_manager_ctrl_c.py   # 1 passed
```

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
