### PR TITLE
fix(submit): make create_submit_file.bash cwd-independent, skip caches, report size

### DIFF
--- a/create_submit_file.bash
+++ b/create_submit_file.bash
@@ -1,3 +1,22 @@
 #!/bin/bash
+# Pack aichallenge/workspace/src/aichallenge_submit into submit/aichallenge_submit.tar.gz.
+set -euo pipefail
 
-tar zcvf submit/aichallenge_submit.tar.gz -C ./aichallenge/workspace/src aichallenge_submit
+# Work from the repository root so the script can be called from any directory.
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+out="submit/aichallenge_submit.tar.gz"
+# Upload limit of the submission site (MB). Override with AIC_SUBMIT_MAX_MB if it changes.
+max_mb="${AIC_SUBMIT_MAX_MB:-20}"
+
+mkdir -p submit
+tar zcvf "${out}" \
+    --exclude='__pycache__' \
+    --exclude='*.pyc' \
+    -C ./aichallenge/workspace/src aichallenge_submit
+
+size_bytes="$(wc -c <"${out}")"
+echo "[INFO] ${out}: ${size_bytes} bytes"
+if [ "${size_bytes}" -gt $((max_mb * 1024 * 1024)) ]; then
+    echo "[WARN] ${out} is larger than ${max_mb} MB and may be rejected by the submission site." >&2
+fi

--- a/create_submit_file.bash
+++ b/create_submit_file.bash
@@ -9,6 +9,13 @@ out="submit/aichallenge_submit.tar.gz"
 # Upload limit of the submission site (MB). Override with AIC_SUBMIT_MAX_MB if it changes.
 max_mb="${AIC_SUBMIT_MAX_MB:-20}"
 
+# Validate before writing anything: must be a plain decimal integer (no sign, no
+# fraction, no leading-zero octal ambiguity for arithmetic below).
+if ! [[ ${max_mb} =~ ^[0-9]+$ ]]; then
+    echo "[ERROR] AIC_SUBMIT_MAX_MB must be a decimal integer (got: '${max_mb}')." >&2
+    exit 1
+fi
+
 mkdir -p submit
 tar zcvf "${out}" \
     --exclude='__pycache__' \
@@ -17,6 +24,6 @@ tar zcvf "${out}" \
 
 size_bytes="$(wc -c <"${out}")"
 echo "[INFO] ${out}: ${size_bytes} bytes"
-if [ "${size_bytes}" -gt $((max_mb * 1024 * 1024)) ]; then
+if [ "${size_bytes}" -gt $((10#${max_mb} * 1024 * 1024)) ]; then
     echo "[WARN] ${out} is larger than ${max_mb} MB and may be rejected by the submission site." >&2
 fi

--- a/docs/interface/participant-interface.md
+++ b/docs/interface/participant-interface.md
@@ -42,7 +42,10 @@
 `create_submit_file.bash` は次のコマンドで tar を生成します。
 
 ```bash
-tar zcvf submit/aichallenge_submit.tar.gz -C ./aichallenge/workspace/src aichallenge_submit
+tar zcvf submit/aichallenge_submit.tar.gz \
+    --exclude='__pycache__' \
+    --exclude='*.pyc' \
+    -C ./aichallenge/workspace/src aichallenge_submit
 ```
 
 tar 内の最上位エントリは `aichallenge_submit/` のみです。独自に tar を生成する場合も、内側の最上位ディレクトリ名は **必ず `aichallenge_submit/`** にしてください。


### PR DESCRIPTION
`create_submit_file.bash` は相対パスの 1 行で、リポジトリ直下以外から呼ぶと `tar: Failed to open 'submit/aichallenge_submit.tar.gz'` で失敗し、ホストの `__pycache__/*.pyc` も同梱します。サイズも表示されないため、提出サイトの上限（アップロード画面で 20 MB と表示）を超えたかどうかがアップロード時まで分かりません。

スクリプト位置へ `cd`、`set -euo pipefail`、`__pycache__`・`*.pyc` を除外、作成後にバイト数を表示し、`AIC_SUBMIT_MAX_MB`（既定 20）を超えたら警告するようにしました（警告のみでファイルは作成されます）。`docs/interface/participant-interface.md` の該当コマンド例も同じ除外オプション付きに更新しました。

確認: `/` から実行して exit 0、pyc 0 件、`AIC_SUBMIT_MAX_MB=1` で警告。`release_submit.bash` からの呼び出しも従来どおり（repo root へ `cd` してからファイルの存在のみを要求するため影響なし）。

`create_submit_file.bash` is a single line with relative paths. Called from any directory other than the repo root, it fails with `tar: Failed to open 'submit/aichallenge_submit.tar.gz'`. It also packs host `__pycache__/*.pyc`, and it never shows the archive size, so exceeding the submission site's upload limit (shown as 20 MB in the upload dialog) is discovered only at upload time.

This PR `cd`s to the script's directory, adds `set -euo pipefail`, excludes `__pycache__` and `*.pyc`, prints the byte size, and warns (without failing) above `AIC_SUBMIT_MAX_MB` (default 20). The quoted command example in `docs/interface/participant-interface.md` was updated to match the new exclude flags.

Tested from `/` on branch `fix/create-submit-file-hygiene` (base `upstream/dev` == `ac3f92944ed2043a9e9bfeaa934ffaaa38760245`, confirmed unchanged for these files): exit 0, no `.pyc`/`__pycache__` entries in the archive, and the warning appears with `AIC_SUBMIT_MAX_MB=1`. The call from `release_submit.bash` is unchanged.

## Before (original script, run from `/`)
```
$ ( cd / && bash /tmp/exec/infra06-before/create_submit_file.bash >/dev/null 2>/tmp/exec/infra06-before.err ); echo "exit=$?"
exit=1
$ cat /tmp/exec/infra06-before.err
tar: Failed to open 'submit/aichallenge_submit.tar.gz'
```

## After (patched script, run from `/`, with an injected `__pycache__` dir first)
```
$ ( cd / && bash "$OLDPWD/create_submit_file.bash" >/dev/null ); echo "exit=$?"
exit=0

$ tar tzf submit/aichallenge_submit.tar.gz | grep -c __pycache__
0

$ AIC_SUBMIT_MAX_MB=1 ./create_submit_file.bash 2>&1 >/dev/null | tail -1
[WARN] submit/aichallenge_submit.tar.gz is larger than 1 MB and may be rejected by the submission site.
```

## Lint
```
$ uvx -q pre-commit run --files create_submit_file.bash docs/interface/participant-interface.md
check for merge conflicts................................................Passed
check xml............................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
shellcheck...............................................................Passed
shfmt....................................................................Passed
```

## Risks / rollback
- Excluding `*.pyc` could matter only to a submission that ships bytecode instead of sources, which colcon/ament does not use. Maintainers should confirm this is acceptable.
- The 20 MB default reflects the upload dialog as observed on 2026-08-28; maintainers should set the real documented value if it differs.
- Rollback: revert the single commit.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
