### PR TITLE
ci: run the pure-Python vehicle console tests on pull requests

### DIFF
--- a/.github/workflows/python-unit-test.yaml
+++ b/.github/workflows/python-unit-test.yaml
@@ -1,0 +1,18 @@
+name: python-unit-test
+
+# Pure-Python unit tests that need neither ROS nor a GPU. colcon-build-test runs with
+# skip-tests: true, so without this job these tests are never executed in CI.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  unittest:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: vehicle console (vehicle/tests)
+        run: python -m unittest discover -s vehicle/tests -p '*_test.py' -v


### PR DESCRIPTION
`colcon-build-test` は `skip-tests: true` のため、`vehicle/tests` の 71 件（標準ライブラリのみ、0.01 秒）を含むテストが CI で一度も実行されていません。ROS も GPU も不要な `python -m unittest discover -s vehicle/tests` を PR ごとに実行するジョブを追加しました（Ubuntu 22.04 / Python 3.10）。`remote/tests` はこのブランチにはまだ存在しないため対象外です。追加された場合は 1 ステップで対象にできます。

`colcon-build-test` runs with `skip-tests: true`, so the repo's tests are never executed in CI. That includes the 71 vehicle console tests in `vehicle/tests`, which need only the standard library and finish in 0.01 s (confirmed locally: `Ran 71 tests in 0.007s / OK`). This PR adds a job that runs `python -m unittest discover -s vehicle/tests` on every PR (Ubuntu 22.04, Python 3.10, no ROS, no GPU). `remote/tests` does not exist on this branch yet, so it is not covered here; once it lands, it can be covered with one more step.

## Test plan
- `python3 -m unittest discover -s vehicle/tests -p '*_test.py' -v` passes locally: 71 tests, OK.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/python-unit-test.yaml'))"` succeeds.
- `pre-commit run --files .github/workflows/python-unit-test.yaml` passes (check-yaml, end-of-file-fixer, etc.).
- The job itself can only be proven by this PR's own CI run once opened.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
