### PR TITLE
fix(docker): reject --submit paths the eval build context cannot see

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -48,6 +48,24 @@ LOG_FILE="output/docker/${ts}-docker_build-$$.log"
 mkdir -p output/docker output/latest
 ln -sfn "${PWD}/${LOG_FILE}" output/latest/docker_build.log
 
+# The default tarball is only as fresh as the last ./create_submit_file.bash run. Warn when the
+# source tree has changed since, so an eval build does not silently test an old submission.
+# AIC_STRICT_SUBMIT=1 turns the warning into an error.
+DEFAULT_SUBMIT_TAR="submit/aichallenge_submit.tar.gz"
+SUBMIT_SRC_DIR="aichallenge/workspace/src/aichallenge_submit"
+if [ "$target" = "eval" ] && [ "${SUBMIT_TAR:-${DEFAULT_SUBMIT_TAR}}" = "${DEFAULT_SUBMIT_TAR}" ] &&
+    [ -f "${DEFAULT_SUBMIT_TAR}" ] && [ -d "${SUBMIT_SRC_DIR}" ]; then
+    newer_file="$(find "${SUBMIT_SRC_DIR}" -type f -newer "${DEFAULT_SUBMIT_TAR}" -not -path '*/__pycache__/*' -print -quit)"
+    if [ -n "${newer_file}" ]; then
+        echo "[WARN] ${DEFAULT_SUBMIT_TAR} is older than ${newer_file}" >&2
+        echo "[WARN] The eval image will contain the submission as it was when the tarball was made." >&2
+        echo "[WARN] Run ./create_submit_file.bash first to evaluate your current code." >&2
+        if [ "${AIC_STRICT_SUBMIT:-0}" = "1" ]; then
+            exit 1
+        fi
+    fi
+fi
+
 BUILD_ARGS=()
 if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     if [ ! -f "${SUBMIT_TAR}" ]; then

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -72,10 +72,33 @@ if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
         echo "[ERROR] submit file not found: ${SUBMIT_TAR}" >&2
         exit 1
     fi
+    # The Dockerfile COPYs SUBMIT_TAR from the build context (repo root minus .dockerignore).
+    # Accept an absolute path inside the repo by making it relative; reject anything docker
+    # cannot see, instead of failing with "not found" after the no-cache build has started.
+    repo_real="$(realpath .)"
+    submit_real="$(realpath "${SUBMIT_TAR}")"
+    case "${submit_real}" in
+    "${repo_real}"/output/* | "${repo_real}"/outputs/* | "${repo_real}"/.git/*)
+        echo "[ERROR] ${SUBMIT_TAR} is excluded from the build context by .dockerignore." >&2
+        echo "        Copy it to submit/ and pass: --submit submit/$(basename "${SUBMIT_TAR}")" >&2
+        exit 1
+        ;;
+    "${repo_real}"/*)
+        SUBMIT_TAR="${submit_real#"${repo_real}"/}"
+        ;;
+    *)
+        echo "[ERROR] ${SUBMIT_TAR} is outside the repository, so docker build cannot COPY it." >&2
+        echo "        Copy it to submit/ and pass: --submit submit/$(basename "${SUBMIT_TAR}")" >&2
+        exit 1
+        ;;
+    esac
     BUILD_ARGS+=(--build-arg "SUBMIT_TAR=${SUBMIT_TAR}")
     echo "[INFO] Using submit tar: ${SUBMIT_TAR}"
 elif [ "$target" != "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     echo "[WARN] --submit is only used for target=eval (ignored): ${SUBMIT_TAR}" >&2
+elif [ "$target" = "eval" ] && [ ! -f "${DEFAULT_SUBMIT_TAR}" ]; then
+    echo "[ERROR] ${DEFAULT_SUBMIT_TAR} not found. Run ./create_submit_file.bash first, or pass --submit <file>." >&2
+    exit 1
 fi
 
 # shellcheck disable=SC2086

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -66,6 +66,40 @@ if [ "$target" = "eval" ] && [ "${SUBMIT_TAR:-${DEFAULT_SUBMIT_TAR}}" = "${DEFAU
     fi
 fi
 
+# Check whether a path relative to the repo root is excluded from the docker build context by
+# .dockerignore. Handles the pattern shapes actually used in that file: a bare directory/path
+# prefix (matches itself and everything under it), the same prefix with a trailing "/**", and a
+# "**/<name>"-style pattern (matches any path component equal to <name>, or a glob against the
+# basename when <name> itself contains a wildcard, e.g. "**/*.pyc").
+path_excluded_by_dockerignore() {
+    local path="$1" ignore_file="${repo_real}/.dockerignore"
+    [ -f "${ignore_file}" ] || return 1
+    local pat sub base
+    while IFS= read -r pat; do
+        pat="${pat%$'\r'}"
+        # Trim leading/trailing whitespace.
+        pat="${pat#"${pat%%[![:space:]]*}"}"
+        pat="${pat%"${pat##*[![:space:]]}"}"
+        [ -z "${pat}" ] && continue
+        case "${pat}" in '#'*) continue ;; esac
+        pat="${pat%/\*\*}"
+        pat="${pat#./}"
+        if [[ ${pat} == \*\*/* ]]; then
+            sub="${pat#\*\*/}"
+            if [[ ${sub} == *'*'* ]]; then
+                base="${path##*/}"
+                # shellcheck disable=SC2053 # intentional glob match: sub is a pattern like "*.pyc"
+                [[ ${base} == ${sub} ]] && return 0
+            else
+                case "/${path}/" in */"${sub}"/*) return 0 ;; esac
+            fi
+        else
+            [[ ${path} == "${pat}" || ${path} == "${pat}"/* ]] && return 0
+        fi
+    done <"${ignore_file}"
+    return 1
+}
+
 BUILD_ARGS=()
 if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     if [ ! -f "${SUBMIT_TAR}" ]; then
@@ -78,13 +112,14 @@ if [ "$target" = "eval" ] && [ -n "${SUBMIT_TAR}" ]; then
     repo_real="$(realpath .)"
     submit_real="$(realpath "${SUBMIT_TAR}")"
     case "${submit_real}" in
-    "${repo_real}"/output/* | "${repo_real}"/outputs/* | "${repo_real}"/.git/*)
-        echo "[ERROR] ${SUBMIT_TAR} is excluded from the build context by .dockerignore." >&2
-        echo "        Copy it to submit/ and pass: --submit submit/$(basename "${SUBMIT_TAR}")" >&2
-        exit 1
-        ;;
     "${repo_real}"/*)
-        SUBMIT_TAR="${submit_real#"${repo_real}"/}"
+        submit_rel="${submit_real#"${repo_real}"/}"
+        if path_excluded_by_dockerignore "${submit_rel}"; then
+            echo "[ERROR] ${SUBMIT_TAR} is excluded from the build context by .dockerignore." >&2
+            echo "        Copy it to submit/ and pass: --submit submit/$(basename "${SUBMIT_TAR}")" >&2
+            exit 1
+        fi
+        SUBMIT_TAR="${submit_rel}"
         ;;
     *)
         echo "[ERROR] ${SUBMIT_TAR} is outside the repository, so docker build cannot COPY it." >&2


### PR DESCRIPTION
# fix(docker): reject --submit paths the eval build context cannot see

Depends on #320 (RK-INFRA-04, `theCodeForgerHQ:feat/eval-stale-submit-warning`): this branch is based on that PR's head commit (`e44d037a65d7b5f7b5c91b5ddb17224d6bcfb7e1`) because it introduces `DEFAULT_SUBMIT_TAR`, which this fix reuses.

## 日本語

評価用 Dockerfile は `COPY ${SUBMIT_TAR}` でビルドコンテキスト（リポジトリ直下、`.dockerignore` 除外後）から tar を取ります。`docker_build.sh` は `-f` しか確認しないため、リポジトリ外の絶対パス・`output/` 配下（`.dockerignore` で除外）・既定 tar の未作成は、no-cache ビルド開始後に BuildKit の `failed to compute cache key ... not found` という分かりにくいエラーになります。

`realpath` で判定し、リポジトリ内の絶対パスは相対パスに変換、それ以外は「submit/ にコピーして `--submit submit/<名前>` を指定」と案内して即座に終了します。既定 tar が無い場合も `./create_submit_file.bash` を案内します。

`docs/interface/participant-interface.md:54` の「リポジトリ直下の相対パス」というルールをスクリプト側で保証するものです。

## English

The eval Dockerfile takes the tarball with `COPY ${SUBMIT_TAR}` from the build context (the repo root, minus `.dockerignore`). `docker_build.sh` only checked `-f` for existence, so an absolute path outside the repo, a file under `output/` (excluded by `.dockerignore`), or a missing default tarball all failed only after the no-cache build had started, with BuildKit's opaque `failed to compute cache key ... not found`.

The script now resolves the path with `realpath`. An absolute path inside the repo becomes relative; anything else fails immediately with "copy it to submit/ and pass `--submit submit/<name>`". A missing default tarball points to `./create_submit_file.bash`.

This enforces the rule already written in `docs/interface/participant-interface.md:54` ("a path relative to the repository root").

## Before (defect reproduced on pre-patch `feat/eval-stale-submit-warning`, with a fake `docker` echoing its args)

```
=== BEFORE TEST ===
[INFO] Using submit tar: /tmp/outside.tar.gz
[docker] build --no-cache --progress=plain --target eval --build-arg SUBMIT_TAR=/tmp/outside.tar.gz -t aichallenge-2025-eval .
========================================================
This log is in : output/docker/20260912-200607-docker_build-68349.log
========================================================
exit=0
```
An absolute path outside the repository was silently accepted and passed straight to `docker build`, exit 0 from the script's own point of view; real Docker only fails later at `COPY`, with BuildKit's opaque `failed to compute cache key ... not found`.

## After (patched branch, same fake `docker`)

```
=== CASE 1: outside path ===
[ERROR] /tmp/outside.tar.gz is outside the repository, so docker build cannot COPY it.
        Copy it to submit/ and pass: --submit submit/outside.tar.gz
exit=1

=== CASE 2: inside submit/ absolute path ===
[INFO] Using submit tar: submit/mine.tar.gz
[docker] build --no-cache --progress=plain --target eval --build-arg SUBMIT_TAR=submit/mine.tar.gz -t aichallenge-2025-eval .
========================================================
This log is in : output/docker/20260912-200618-docker_build-69030.log
========================================================
exit=0

=== CASE 3: output/ excluded path ===
[ERROR] output/mine.tar.gz is excluded from the build context by .dockerignore.
        Copy it to submit/ and pass: --submit submit/mine.tar.gz
exit=1

=== CASE 4: missing default tarball ===
[ERROR] submit/aichallenge_submit.tar.gz not found. Run ./create_submit_file.bash first, or pass --submit <file>.
exit=1
```

## Lint

`uvx pre-commit run --files docker_build.sh` passed all hooks (including `shellcheck` and `shfmt`); `bash -n docker_build.sh` was also clean.

## Verification commands

```bash
mkdir -p /tmp/fakebin && printf '#!/bin/bash\necho "[docker] $*"\n' > /tmp/fakebin/docker && chmod +x /tmp/fakebin/docker
tar czf /tmp/outside.tar.gz -C aichallenge/workspace/src aichallenge_submit
PATH=/tmp/fakebin:$PATH ./docker_build.sh eval --submit /tmp/outside.tar.gz; echo "exit=$?"   # fix: ERROR, exit 1
cp /tmp/outside.tar.gz submit/mine.tar.gz
PATH=/tmp/fakebin:$PATH ./docker_build.sh eval --submit "$PWD/submit/mine.tar.gz"             # fix: SUBMIT_TAR=submit/mine.tar.gz
mkdir -p output && cp /tmp/outside.tar.gz output/mine.tar.gz
PATH=/tmp/fakebin:$PATH ./docker_build.sh eval --submit output/mine.tar.gz; echo "exit=$?"    # fix: ERROR, exit 1
rm -f submit/aichallenge_submit.tar.gz submit/mine.tar.gz
PATH=/tmp/fakebin:$PATH ./docker_build.sh eval; echo "exit=$?"                                # fix: ERROR, exit 1
```

## Risks / rollback

- `realpath` requires GNU coreutils, standard on Ubuntu 22.04 and present on macOS 13+.
- Someone relying on a symlink from `submit/` into `output/` would now be rejected; docker would have rejected that too, only later.
- Rollback: revert the single commit.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
