### PR TITLE
docs(setup): point doctor next steps at commands that exist

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -1192,9 +1192,9 @@ doctor() {
     echo "${INFO} 3) Download AWSIM:     ./setup.bash download awsim"
     echo "${INFO} 4) Build image:        ./docker_build.sh dev"
     echo "${INFO} 5) Build Autoware:     make autoware-build && docker compose logs -f autoware-build"
-    echo "${INFO} 6) Run evaluation:     ./run_evaluation.bash  (optional: ROSBAG=true CAPTURE=true)"
+    echo "${INFO} 6) Run evaluation:     ./create_submit_file.bash && ./docker_build.sh eval && make eval"
     echo "${INFO} 7) Start dev:          make dev   (ROS_DOMAIN_ID is read from .env)"
-    echo "${INFO} 8) Dev shell:          docker compose run --rm -it --entrypoint bash autoware"
+    echo "${INFO} 8) Dev shell:          make autoware-bash"
 
     return "$failed"
 }


### PR DESCRIPTION
`./setup.bash doctor` の Next steps のうち、6) の `./run_evaluation.bash (optional: ROSBAG=true CAPTURE=true)` はリポジトリ直下に存在せず（実体は評価コンテナ内の `aichallenge/run_evaluation.bash` で、ROSBAG/CAPTURE も参照していません）、8) の `--entrypoint bash` は `docker-entrypoint.sh` を通らないため workspace が source されません。ドキュメントどおりの `./create_submit_file.bash && ./docker_build.sh eval && make eval` と、既存の `make autoware-bash` に置き換えました（表示文言のみの変更）。

In `./setup.bash doctor`'s Next steps, step 6 (`./run_evaluation.bash (optional: ROSBAG=true CAPTURE=true)`) points at a file that does not exist at the repo root. The real script is `aichallenge/run_evaluation.bash` inside the eval container, and it reads neither ROSBAG nor CAPTURE. Step 8 uses `--entrypoint bash`, which bypasses `docker-entrypoint.sh`, so the workspace is not sourced. This PR replaces them with the documented `./create_submit_file.bash && ./docker_build.sh eval && make eval` and the existing `make autoware-bash`. Only the displayed text changes.

## Test evidence

Before (on `docs/setup-doctor-next-steps` branch, before the fix):
```
$ ls ./run_evaluation.bash
ls: ./run_evaluation.bash: No such file or directory
$ grep -n "Run evaluation\|entrypoint bash" setup.bash
1195:    echo "${INFO} 6) Run evaluation:     ./run_evaluation.bash  (optional: ROSBAG=true CAPTURE=true)"
1197:    echo "${INFO} 8) Dev shell:          docker compose run --rm -it --entrypoint bash autoware"
```

Diff applied (via `evidence/rk-infra-patches/RK-INFRA-10.patch`, applied cleanly with `git apply --check`, no hand-editing needed; no drift found between base SHA ac3f92944ed2043a9e9bfeaa934ffaaa38760245 and upstream/dev for setup.bash):
```diff
-    echo "${INFO} 6) Run evaluation:     ./run_evaluation.bash  (optional: ROSBAG=true CAPTURE=true)"
+    echo "${INFO} 6) Run evaluation:     ./create_submit_file.bash && ./docker_build.sh eval && make eval"
     echo "${INFO} 7) Start dev:          make dev   (ROS_DOMAIN_ID is read from .env)"
-    echo "${INFO} 8) Dev shell:          docker compose run --rm -it --entrypoint bash autoware"
+    echo "${INFO} 8) Dev shell:          make autoware-bash"
```

After:
```
$ bash -n setup.bash && echo "bash-n-ok"
bash-n-ok
$ ./setup.bash doctor | sed -n '/Next steps/,$p'
=== Next steps ===
1) If Docker missing:  ./setup.bash bootstrap
2) Pull base image:    ./setup.bash pull image (recommended)
3) Download AWSIM:     ./setup.bash download awsim
4) Build image:        ./docker_build.sh dev
5) Build Autoware:     make autoware-build && docker compose logs -f autoware-build
6) Run evaluation:     ./create_submit_file.bash && ./docker_build.sh eval && make eval
7) Start dev:          make dev   (ROS_DOMAIN_ID is read from .env)
8) Dev shell:          make autoware-bash
$ grep -n "autoware-bash" Makefile
5:	simulator dev dev2 dev3 dev4 driver zenoh download rviz2 down down_all ps autoware-attach autoware-bash eval e2e vehicle-tui
146:autoware-bash:
$ make -n autoware-bash
CMD="bash --rcfile /etc/skel/.bashrc -i" docker compose run --rm --no-deps autoware-command
```

Lint: `uvx pre-commit run --files setup.bash`: check for merge conflicts (Passed), fix end of files (Passed), mixed line ending (Passed), shellcheck (Passed), shfmt (Passed). No new warnings introduced. No em-dashes (U+2014) in the two changed lines.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記のテストで検証しました。 / Prepared with AI coding assistance and verified by the tests above.
