### PR TITLE
fix(remote): reap orphaned joy_node before restarting joy

### DIFF
--- a/remote/gui_tools.py
+++ b/remote/gui_tools.py
@@ -501,6 +501,32 @@ COMMANDS: List[CommandSpec] = [
 
 SPEC_MAP: Dict[str, CommandSpec] = {spec.label: spec for spec in COMMANDS}
 
+# self.processes は GUI 自身が起動したプロセスしか把握できない。前回セッションの
+# クラッシュや手動起動で残った同種プロセスは Stop/Restart を押しても消せず、
+# Restart Joy が孤児に加えてもう1つ ros2 run joy joy_node を起こしてしまう (RC13)。
+# 巻き込み事故を避けるため、パターンをここで明示登録した log_key だけ pkill で掃除する。
+ORPHAN_KILL_PATTERNS: Dict[str, str] = {
+    "joy": "ros2 run joy joy_node",
+}
+
+
+def kill_orphan_pattern(log_key: str, timeout: float = 3.0) -> bool:
+    """log_key に登録された pattern で pkill する。登録が無ければ何もしない。
+
+    戻り値は「一致するプロセスを見つけて killed した (pkill の終了コード 0)」かどうか。
+    Tk に依存しないのでテストしやすいよう、GUI クラスから切り出してある。
+    """
+    pattern = ORPHAN_KILL_PATTERNS.get(log_key)
+    if pattern is None:
+        return False
+    result = subprocess.run(
+        ["pkill", "-f", pattern],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.returncode == 0
+
 COLUMN_LAYOUT = [
     ("Zenoh", ["Start Zenoh", "Stop Zenoh", "Restart Zenoh"]),
     ("RViz", ["Start RViz", "Stop RViz", "Restart RViz"]),
@@ -925,6 +951,8 @@ class RemoteGui:
         with self._processes_lock:
             entry = self.processes.pop(log_key, None)
         if entry is None:
+            # 追跡が無くても実機には孤児が残っているかもしれない (RC13)。
+            self._reap_orphan(log_key)
             self._refresh_button_states()
             if on_terminated is not None:
                 on_terminated()
@@ -982,6 +1010,24 @@ class RemoteGui:
         except tk.TclError:
             # ウィンドウが既に破棄されている場合は諦める (_on_close / _terminate_all 側で後始末される)
             pass
+
+    def _reap_orphan(self, log_key: str) -> None:
+        """GUI が追跡していない同種プロセスを掃除する (RC13)。
+
+        対象は ORPHAN_KILL_PATTERNS に明示登録された log_key だけに限定し、
+        無関係なプロセスを巻き込まない。pkill は数十 ms で戻るのでメインスレッドで
+        同期的に呼んでも UI をブロックしない。
+        """
+        try:
+            killed = kill_orphan_pattern(log_key)
+        except Exception as exc:  # pragma: no cover - defensive
+            self._append_log(log_key, f"[orphan cleanup failed: {exc}]\n")
+            return
+        if killed:
+            pattern = ORPHAN_KILL_PATTERNS[log_key]
+            self._append_log(
+                log_key, f"[orphan cleanup: killed stray process matching {pattern!r}]\n"
+            )
 
     @staticmethod
     def _signal_process_group(process: subprocess.Popen[str], sig: int) -> None:

--- a/remote/gui_tools.py
+++ b/remote/gui_tools.py
@@ -776,9 +776,10 @@ class RemoteGui:
         logs_frame.rowconfigure(0, weight=1)
 
     def _handle_stop_single(self, log_key: str) -> None:
-        if not self._process_running(log_key):
-            self._append_log(log_key, '[no running process]\n')
-            return
+        # _process_running() で先に弾くと、GUI が追跡していない孤児 (RC13) は
+        # 「動いていない」ことになって _stop_process 自体に届かず、Restart だけ
+        # 掃除できて Stop では掃除できないという食い違いになる。追跡の有無に
+        # 関わらず _stop_process に任せ、孤児の掃除も同じ経路を通す。
         self._append_log(log_key, '[stop requested]\n')
         self._stop_process(log_key)
 
@@ -951,8 +952,10 @@ class RemoteGui:
         with self._processes_lock:
             entry = self.processes.pop(log_key, None)
         if entry is None:
-            # 追跡が無くても実機には孤児が残っているかもしれない (RC13)。
-            self._reap_orphan(log_key)
+            # 追跡が無くても実機には孤児が残っているかもしれない (RC13)。「Stop」も
+            # ここを通すので、追跡していないというだけで掃除をスキップしない。
+            if not self._reap_orphan(log_key):
+                self._append_log(log_key, "[no running process]\n")
             self._refresh_button_states()
             if on_terminated is not None:
                 on_terminated()
@@ -1011,8 +1014,8 @@ class RemoteGui:
             # ウィンドウが既に破棄されている場合は諦める (_on_close / _terminate_all 側で後始末される)
             pass
 
-    def _reap_orphan(self, log_key: str) -> None:
-        """GUI が追跡していない同種プロセスを掃除する (RC13)。
+    def _reap_orphan(self, log_key: str) -> bool:
+        """GUI が追跡していない同種プロセスを掃除する (RC13)。戻り値は掃除できたか。
 
         対象は ORPHAN_KILL_PATTERNS に明示登録された log_key だけに限定し、
         無関係なプロセスを巻き込まない。pkill は数十 ms で戻るのでメインスレッドで
@@ -1022,12 +1025,13 @@ class RemoteGui:
             killed = kill_orphan_pattern(log_key)
         except Exception as exc:  # pragma: no cover - defensive
             self._append_log(log_key, f"[orphan cleanup failed: {exc}]\n")
-            return
+            return False
         if killed:
             pattern = ORPHAN_KILL_PATTERNS[log_key]
             self._append_log(
                 log_key, f"[orphan cleanup: killed stray process matching {pattern!r}]\n"
             )
+        return killed
 
     @staticmethod
     def _signal_process_group(process: subprocess.Popen[str], sig: int) -> None:

--- a/remote/tests/gui_tools_test.py
+++ b/remote/tests/gui_tools_test.py
@@ -11,9 +11,13 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 
+from unittest import mock  # noqa: E402
+
 from gui_tools import (  # noqa: E402
+    ORPHAN_KILL_PATTERNS,
     VALID_VEHICLE_IDS,
     default_vehicle_id,
+    kill_orphan_pattern,
     read_env_vehicle_id,
 )
 
@@ -70,6 +74,31 @@ class TestDefaultVehicleId(unittest.TestCase):
             with self.subTest(value=value):
                 got = default_vehicle_id(_write_env(f"VEHICLE_ID={value}\n"))
                 self.assertNotIn(got, VALID_VEHICLE_IDS)
+
+
+class TestKillOrphanPattern(unittest.TestCase):
+    def test_unregistered_log_key_does_not_call_pkill(self):
+        # zenoh/rviz は明示登録が無い。無関係なプロセスを巻き込まないよう pkill 自体を
+        # 呼ばない (RC13)。
+        with mock.patch("gui_tools.subprocess.run") as run:
+            self.assertFalse(kill_orphan_pattern("rviz"))
+        run.assert_not_called()
+
+    def test_joy_is_registered_and_uses_pkill_dash_f(self):
+        self.assertIn("joy", ORPHAN_KILL_PATTERNS)
+        completed = mock.Mock(returncode=0)
+        with mock.patch("gui_tools.subprocess.run", return_value=completed) as run:
+            self.assertTrue(kill_orphan_pattern("joy"))
+        run.assert_called_once()
+        args, kwargs = run.call_args
+        self.assertEqual(args[0], ["pkill", "-f", ORPHAN_KILL_PATTERNS["joy"]])
+        self.assertEqual(kwargs.get("timeout"), 3.0)
+
+    def test_no_match_returns_false(self):
+        # pkill は該当プロセスが無いと非0を返す。誤って「掃除した」とログしないための境界。
+        completed = mock.Mock(returncode=1)
+        with mock.patch("gui_tools.subprocess.run", return_value=completed):
+            self.assertFalse(kill_orphan_pattern("joy"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Restart Joy previously only stopped a joy_node this GUI instance itself tracked; a joy_node orphaned by a crashed/prior GUI session, or started manually, was left running and a second joy_node got launched alongside it.
- Reintroduce a narrowly scoped `pkill -f` fallback (per log_key, `joy` only for now) that fires only when nothing is tracked, so it can't collide with the process-group teardown path used for GUI-launched processes.

## Test plan
- `python3 tests/gui_tools_test.py` (14 passed, incl. 3 new tests for `kill_orphan_pattern`)